### PR TITLE
Refactor module load and settings registration

### DIFF
--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -1,8 +1,6 @@
 import { BaseModule } from "base";
-import { BaseSettingsModel } from "Settings/Models/base";
 import { ModuleCategory } from "Settings/setting_definitions";
 import { OnActivity, SendAction, getRandomInt, removeAllHooksByModule, setOrIgnoreBlush, hookFunction, ICONS } from "../utils";
-import { hypnoActivated } from "./hypno";
 
 export interface ActivityTarget {
     Name: AssetGroupItemName;

--- a/src/Modules/boops.ts
+++ b/src/Modules/boops.ts
@@ -15,6 +15,12 @@ export class BoopsModule extends BaseModule {
     //     return GuiBoops;
     // }
 
+    get defaultSettings() {
+        return <BaseSettingsModel>{
+            enabled: true
+        };
+    }
+
     load(): void {
         OnActivity(100, ModuleCategory.Boops, (data, sender, msg, metadata) => {
             if (!this.Enabled)

--- a/src/Modules/boops.ts
+++ b/src/Modules/boops.ts
@@ -1,13 +1,19 @@
 import { BaseModule } from "base";
 import { BaseSettingsModel } from "Settings/Models/base";
-import { ModuleCategory } from "Settings/setting_definitions";
+import { ModuleCategory, Subscreen } from "Settings/setting_definitions";
 import { OnActivity, SendAction, getRandomInt, removeAllHooksByModule, setOrIgnoreBlush } from "../utils";
 import { hypnoActivated } from "./hypno";
+import { GuiBoops } from "Settings/boops";
 
 export class BoopsModule extends BaseModule {
     boops: number = 0;
     boopShutdown: boolean = false;
     boopDecreaseLoop: number = 0;
+
+    // Disabled as it's managed via General
+    // get settingsScreen(): Subscreen | null {
+    //     return GuiBoops;
+    // }
 
     load(): void {
         OnActivity(100, ModuleCategory.Boops, (data, sender, msg, metadata) => {

--- a/src/Modules/collar.ts
+++ b/src/Modules/collar.ts
@@ -11,7 +11,6 @@ enum PassoutReason {
 }
 
 export class CollarModule extends BaseModule {
-
     get settings(): CollarSettingsModel {
 		return super.settings as CollarSettingsModel;
 	}
@@ -32,6 +31,16 @@ export class CollarModule extends BaseModule {
 
     get settingsScreen(): Subscreen | null {
         return GuiCollar;
+    }
+
+    get defaultSettings() {
+		return <CollarSettingsModel>{
+            enabled: false,
+            allowedMembers: Player.Ownership?.MemberNumber + "" ?? "",
+            chokeLevel: 0,
+            tightTrigger: "tight",
+            looseTrigger: "loose"
+        };
     }
 
     load(): void {

--- a/src/Modules/collar.ts
+++ b/src/Modules/collar.ts
@@ -1,7 +1,8 @@
 import { BaseModule } from 'base';
 import { CollarModel, CollarSettingsModel } from 'Settings/Models/collar';
-import { ModuleCategory } from 'Settings/setting_definitions';
+import { ModuleCategory, Subscreen } from 'Settings/setting_definitions';
 import { settingsSave, parseMsgWords, SendAction, OnChat, getRandomInt, hookFunction, removeAllHooksByModule, OnActivity, OnAction, setOrIgnoreBlush, getCharacter } from '../utils';
+import { GuiCollar } from 'Settings/collar';
 
 enum PassoutReason {
     COLLAR,
@@ -27,6 +28,10 @@ export class CollarModule extends BaseModule {
         var collarName = collar?.Craft?.Name ?? (collar?.Asset.Name ?? "");
         var collarCreator = collar?.Craft?.MemberNumber ?? 0;
         return collarName == this.settings.collar.name && collarCreator == this.settings.collar.creator;
+    }
+
+    get settingsScreen(): Subscreen | null {
+        return GuiCollar;
     }
 
     load(): void {

--- a/src/Modules/hypno.ts
+++ b/src/Modules/hypno.ts
@@ -1,12 +1,17 @@
 import { BaseModule } from 'base';
 import { HypnoSettingsModel } from 'Settings/Models/hypno';
-import { ModuleCategory } from 'Settings/setting_definitions';
+import { ModuleCategory, Subscreen } from 'Settings/setting_definitions';
 import { settingsSave, parseMsgWords, OnChat, OnAction, OnActivity, SendAction, getRandomInt, hookFunction, removeAllHooksByModule, callOriginal, setOrIgnoreBlush, escapeRegExp } from '../utils';
+import { GuiHypno } from 'Settings/hypno';
 
 export class HypnoModule extends BaseModule {
     get settings(): HypnoSettingsModel {
 		return super.settings as HypnoSettingsModel;
 	}
+
+    get settingsScreen(): Subscreen | null {
+        return GuiHypno;
+    }
 
     load(): void {
         CommandCombine([

--- a/src/Modules/hypno.ts
+++ b/src/Modules/hypno.ts
@@ -6,11 +6,22 @@ import { GuiHypno } from 'Settings/hypno';
 
 export class HypnoModule extends BaseModule {
     get settings(): HypnoSettingsModel {
-		return super.settings as HypnoSettingsModel;
+        return super.settings as HypnoSettingsModel;
 	}
 
     get settingsScreen(): Subscreen | null {
         return GuiHypno;
+    }
+
+    get defaultSettings(){
+        return <HypnoSettingsModel>{
+            enabled: false,
+            activatedAt: 0,
+            cycleTime: 30,
+            enableCycle: true,
+            overrideMemberIds: "",
+            overrideWords: ""
+        };
     }
 
     load(): void {

--- a/src/Modules/lipstick.ts
+++ b/src/Modules/lipstick.ts
@@ -2,12 +2,19 @@ import { BaseModule } from "base";
 import { ModuleCategory, Subscreen } from "Settings/setting_definitions";
 import { OnActivity, removeAllHooksByModule, setOrIgnoreBlush } from "../utils";
 import { GuiLipstick } from "Settings/lipstick";
+import { BaseSettingsModel } from "Settings/Models/base";
 
 export class LipstickModule extends BaseModule {
     // Disabled as it's managed via General
     // get settingsScreen(): Subscreen | null {
     //     return GuiLipstick;
     // }
+
+    get defaultSettings() {
+        return <BaseSettingsModel>{
+            enabled: true
+        };
+    }
 
     load(): void {
         OnActivity(100, ModuleCategory.Lipstick, (data, sender, msg, metadata) => {

--- a/src/Modules/lipstick.ts
+++ b/src/Modules/lipstick.ts
@@ -1,8 +1,14 @@
 import { BaseModule } from "base";
-import { ModuleCategory } from "Settings/setting_definitions";
+import { ModuleCategory, Subscreen } from "Settings/setting_definitions";
 import { OnActivity, removeAllHooksByModule, setOrIgnoreBlush } from "../utils";
+import { GuiLipstick } from "Settings/lipstick";
 
 export class LipstickModule extends BaseModule {
+    // Disabled as it's managed via General
+    // get settingsScreen(): Subscreen | null {
+    //     return GuiLipstick;
+    // }
+
     load(): void {
         OnActivity(100, ModuleCategory.Lipstick, (data, sender, msg, metadata) => {
             if (!this.Enabled)

--- a/src/Modules/misc.ts
+++ b/src/Modules/misc.ts
@@ -2,18 +2,25 @@ import { BaseModule } from "base";
 import { MiscSettingsModel } from "Settings/Models/base";
 import { ModuleCategory, Subscreen } from "Settings/setting_definitions";
 import { getRandomInt, hookFunction, OnAction, OnActivity, removeAllHooksByModule, SendAction, setOrIgnoreBlush } from "../utils";
-import { GuiMisc } from "Settings/misc";
 
 export class MiscModule extends BaseModule {
     get settings(): MiscSettingsModel {
-		(<any>Player.LSCG)[this.constructor.name] = (<any>Player.LSCG)[this.constructor.name] || {};
-		return (<any>Player.LSCG)[this.constructor.name];
+        return super.settings as MiscSettingsModel;
 	}
 
     // Disabled as it's managed via General
     // get settingsScreen(): Subscreen | null {
     //     return GuiMisc;
     // }
+
+    get defaultSettings() {
+        return <MiscSettingsModel>{
+            enabled: true,
+            chloroformEnabled: false,
+            handChokeEnabled: false,
+            gagChokeEnabled: false
+        };
+    }
 
     load(): void {
         // Kneel on lap sit

--- a/src/Modules/misc.ts
+++ b/src/Modules/misc.ts
@@ -1,13 +1,19 @@
 import { BaseModule } from "base";
 import { MiscSettingsModel } from "Settings/Models/base";
-import { ModuleCategory } from "Settings/setting_definitions";
+import { ModuleCategory, Subscreen } from "Settings/setting_definitions";
 import { getRandomInt, hookFunction, OnAction, OnActivity, removeAllHooksByModule, SendAction, setOrIgnoreBlush } from "../utils";
+import { GuiMisc } from "Settings/misc";
 
 export class MiscModule extends BaseModule {
     get settings(): MiscSettingsModel {
 		(<any>Player.LSCG)[this.constructor.name] = (<any>Player.LSCG)[this.constructor.name] || {};
 		return (<any>Player.LSCG)[this.constructor.name];
 	}
+
+    // Disabled as it's managed via General
+    // get settingsScreen(): Subscreen | null {
+    //     return GuiMisc;
+    // }
 
     load(): void {
         // Kneel on lap sit

--- a/src/Settings/boops.ts
+++ b/src/Settings/boops.ts
@@ -2,12 +2,14 @@ import { BaseSettingsModel } from "./Models/base";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiBoops extends GuiSubscreen {
-    readonly character : PlayerCharacter;
 
-    constructor(character: PlayerCharacter) {
-		super();
-		this.character = character;
-    }
+	get name(): string {
+		return "Boops";
+	}
+
+	get icon(): string {
+		return "Icons/Use.png";
+	}
 
 	get settings(): BaseSettingsModel {
         Player.LSCG.BoopsModule = Player.LSCG.BoopsModule ?? { enabled: true };
@@ -26,5 +28,16 @@ export class GuiBoops extends GuiSubscreen {
 		DrawCheckbox(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64, "", this.settings.enabled ?? false);
 
 		MainCanvas.textAlign = prev;
+	}
+
+	Click(): void {
+		super.Click();
+
+		// Enabled Checkbox
+		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64)){
+			this.settings.enabled = !this.settings.enabled;
+			return;
+		}
+
 	}
 }

--- a/src/Settings/boops.ts
+++ b/src/Settings/boops.ts
@@ -12,8 +12,7 @@ export class GuiBoops extends GuiSubscreen {
 	}
 
 	get settings(): BaseSettingsModel {
-        Player.LSCG.BoopsModule = Player.LSCG.BoopsModule ?? { enabled: true };
-        return Player.LSCG.BoopsModule
+        return super.settings as BaseSettingsModel;
     }
 
     Run() {

--- a/src/Settings/collar.ts
+++ b/src/Settings/collar.ts
@@ -1,26 +1,8 @@
 import { ICONS } from "utils";
 import { CollarModel, CollarSettingsModel } from "./Models/collar";
-import { SettingsModel } from "./Models/settings";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiCollar extends GuiSubscreen {
-
-	get settings(): CollarSettingsModel {
-		if (Player.LSCG === undefined) {
-			Player.LSCG = <SettingsModel>{};
-		}
-		if (Player.LSCG.CollarModule === undefined) {
-			Player.LSCG.CollarModule = <CollarSettingsModel>{ 
-				enabled: false,
-				allowedMembers: Player.Ownership?.MemberNumber + "" ?? "",
-				chokeLevel: 0,
-				tightTrigger: "tight",
-				looseTrigger: "loose"
-			};
-		}
-		return Player.LSCG.CollarModule;		
-	}
-
 	get name(): string {
 		return "Choke Collar";
 	}
@@ -36,6 +18,10 @@ export class GuiCollar extends GuiSubscreen {
 			122875 // fake sera
 		];
 		return allowedChokeMemberNumbers.includes(this.character.MemberNumber ?? 0);
+	}
+
+	get settings(): CollarSettingsModel {
+		return super.settings as CollarSettingsModel;
 	}
 
 	Load(): void {

--- a/src/Settings/collar.ts
+++ b/src/Settings/collar.ts
@@ -1,14 +1,9 @@
+import { ICONS } from "utils";
 import { CollarModel, CollarSettingsModel } from "./Models/collar";
 import { SettingsModel } from "./Models/settings";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiCollar extends GuiSubscreen {
-    readonly character : PlayerCharacter;
-
-    constructor(character: PlayerCharacter) {
-		super();
-		this.character = character;
-    }
 
 	get settings(): CollarSettingsModel {
 		if (Player.LSCG === undefined) {
@@ -24,6 +19,23 @@ export class GuiCollar extends GuiSubscreen {
 			};
 		}
 		return Player.LSCG.CollarModule;		
+	}
+
+	get name(): string {
+		return "Choke Collar";
+	}
+
+	get icon(): string {
+		return ICONS.COLLAR;
+	}
+
+	get enabled(): boolean {
+		const allowedChokeMemberNumbers = [
+			74298, // little sera
+			54618, // megg
+			122875 // fake sera
+		];
+		return allowedChokeMemberNumbers.includes(this.character.MemberNumber ?? 0);
 	}
 
 	Load(): void {
@@ -81,14 +93,20 @@ export class GuiCollar extends GuiSubscreen {
 	Click() {
 		super.Click();
 
+		// Enabled Checkbox
+		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64)){
+			this.settings.enabled = !this.settings.enabled;
+			return;
+		}
+
 		// Update Collar Button
 		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(3) - 32, 200, 64)){
 			var collar = InventoryGet(Player, "ItemNeck");
 			if(!collar){
-				PreferenceMessage = "No Collar Equipped";
+				this.message = "No Collar Equipped";
 			}
 			else{
-				PreferenceMessage = "Collar updated";
+				this.message = "Collar updated";
 				this.settings.collar = <CollarModel>{
 					name: collar.Craft?.Name ?? collar.Asset.Name,
 					creator: collar.Craft?.MemberNumber ?? 0

--- a/src/Settings/global.ts
+++ b/src/Settings/global.ts
@@ -13,8 +13,7 @@ export class GuiGlobal extends GuiSubscreen {
 	}
 
 	get settings(): GlobalSettingsModel {
-        Player.LSCG.GlobalModule = Player.LSCG.GlobalModule ?? { enabled: true, edgeBlur: false };
-        return Player.LSCG.GlobalModule
+        return super.settings as GlobalSettingsModel;
     }
 
     Run() {

--- a/src/Settings/global.ts
+++ b/src/Settings/global.ts
@@ -1,13 +1,16 @@
+import { ICONS } from "utils";
 import { GlobalSettingsModel } from "./Models/base";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiGlobal extends GuiSubscreen {
-    readonly character : PlayerCharacter;
 
-    constructor(character: PlayerCharacter) {
-		super();
-		this.character = character;
-    }
+	get name(): string {
+		return "General";
+	}
+
+	get icon(): string {
+		return ICONS.BDSM;
+	}
 
 	get settings(): GlobalSettingsModel {
         Player.LSCG.GlobalModule = Player.LSCG.GlobalModule ?? { enabled: true, edgeBlur: false };
@@ -54,6 +57,11 @@ export class GuiGlobal extends GuiSubscreen {
 
 	Click() {
 		super.Click();
+
+		// Enabled Checkbox
+		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64)){
+			this.settings.enabled = !this.settings.enabled;
+		}
 
 		// Edge Blur Checkbox
 		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(2) - 32, 64, 64)){

--- a/src/Settings/hypno.ts
+++ b/src/Settings/hypno.ts
@@ -1,14 +1,17 @@
+import { ICONS } from "utils";
 import { HypnoSettingsModel } from "./Models/hypno";
 import { SettingsModel } from "./Models/settings";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiHypno extends GuiSubscreen {
-    readonly character : PlayerCharacter;
 
-    constructor(character: PlayerCharacter) {
-		super();
-		this.character = character;
-    }
+	get name(): string {
+		return "Hypnosis";
+	}
+
+	get icon(): string {
+		return ICONS.HYPNO;
+	}
 
 	get settings(): HypnoSettingsModel {
 		if (Player.LSCG === undefined) {

--- a/src/Settings/hypno.ts
+++ b/src/Settings/hypno.ts
@@ -1,6 +1,5 @@
 import { ICONS } from "utils";
 import { HypnoSettingsModel } from "./Models/hypno";
-import { SettingsModel } from "./Models/settings";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiHypno extends GuiSubscreen {
@@ -14,20 +13,7 @@ export class GuiHypno extends GuiSubscreen {
 	}
 
 	get settings(): HypnoSettingsModel {
-		if (Player.LSCG === undefined) {
-			Player.LSCG = <SettingsModel>{};
-		}
-		if (!Player.LSCG.HypnoModule) {
-			Player.LSCG.HypnoModule = <HypnoSettingsModel>{ 
-				enabled: false,
-				activatedAt: 0,
-				cycleTime: 30,
-				enableCycle: true,
-				overrideMemberIds: "",
-				overrideWords: ""
-			};
-		}
-		return Player.LSCG.HypnoModule;
+		return super.settings as HypnoSettingsModel;
 	}
 
 	Load(): void {

--- a/src/Settings/lipstick.ts
+++ b/src/Settings/lipstick.ts
@@ -1,4 +1,3 @@
-import { BaseSettingsModel } from "./Models/base";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiLipstick extends GuiSubscreen {
@@ -10,11 +9,6 @@ export class GuiLipstick extends GuiSubscreen {
 	get icon(): string {
 		return "Icons/Arousal.png";
 	}
-
-	get settings(): BaseSettingsModel {
-        Player.LSCG.LipstickModule = Player.LSCG.LipstickModule ?? { enabled: true };
-        return Player.LSCG.LipstickModule
-    }
 
     Run() {
 		var prev = MainCanvas.textAlign;

--- a/src/Settings/lipstick.ts
+++ b/src/Settings/lipstick.ts
@@ -2,12 +2,14 @@ import { BaseSettingsModel } from "./Models/base";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiLipstick extends GuiSubscreen {
-    readonly character : PlayerCharacter;
 
-    constructor(character: PlayerCharacter) {
-		super();
-		this.character = character;
-    }
+	get name(): string {
+		return "Lipstick";
+	}
+
+	get icon(): string {
+		return "Icons/Arousal.png";
+	}
 
 	get settings(): BaseSettingsModel {
         Player.LSCG.LipstickModule = Player.LSCG.LipstickModule ?? { enabled: true };
@@ -26,5 +28,15 @@ export class GuiLipstick extends GuiSubscreen {
 		DrawCheckbox(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64, "", this.settings.enabled ?? false);
 
 		MainCanvas.textAlign = prev;
+	}
+
+	Click(): void {
+		super.Click();
+
+		// Enabled Checkbox
+		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64)){
+			this.settings.enabled = !this.settings.enabled;
+			return;
+		}
 	}
 }

--- a/src/Settings/misc.ts
+++ b/src/Settings/misc.ts
@@ -1,13 +1,15 @@
-import { BaseSettingsModel, MiscSettingsModel } from "./Models/base";
+import { MiscSettingsModel } from "./Models/base";
 import { GuiSubscreen } from "./settingBase";
 
 export class GuiMisc extends GuiSubscreen {
-    readonly character : PlayerCharacter;
 
-    constructor(character: PlayerCharacter) {
-		super();
-		this.character = character;
-    }
+	get name(): string {
+		return "Miscellaneous";
+	}
+
+	get icon(): string {
+		return "Icons/General.png";
+	}
 
 	get settings(): MiscSettingsModel {
         Player.LSCG.MiscModule = Player.LSCG.MiscModule ?? { enabled: true, chloroformEnabled: false };

--- a/src/Settings/misc.ts
+++ b/src/Settings/misc.ts
@@ -12,8 +12,7 @@ export class GuiMisc extends GuiSubscreen {
 	}
 
 	get settings(): MiscSettingsModel {
-        Player.LSCG.MiscModule = Player.LSCG.MiscModule ?? { enabled: true, chloroformEnabled: false };
-        return Player.LSCG.MiscModule
+		return super.settings as MiscSettingsModel;
     }
 
     Run() {

--- a/src/Settings/settingBase.ts
+++ b/src/Settings/settingBase.ts
@@ -55,10 +55,9 @@ export abstract class GuiSubscreen {
 		return setSubscreen(screen);
 	}
 
-    get settings(): BaseSettingsModel {
-        Player.LSCG.GlobalModule = Player.LSCG.GlobalModule ?? { enabled: true };
-        return Player.LSCG.GlobalModule
-    }
+	get settings(): BaseSettingsModel {
+		return this.module.settings as BaseSettingsModel;
+	}
 
 	get character(): Character {
 		// Because we're initialized by that instance, it must already exist

--- a/src/Settings/settingBase.ts
+++ b/src/Settings/settingBase.ts
@@ -1,37 +1,76 @@
 import { settingsSave } from "utils";
 import { BaseSettingsModel } from "./Models/base";
-import { SETTING_FUNC_NAMES, SETTING_FUNC_PREFIX, SETTING_NAMES, SETTING_NAME_PREFIX } from "./setting_definitions";
+import { SETTING_FUNC_NAMES, SETTING_FUNC_PREFIX, SETTING_NAME_PREFIX, setSubscreen } from "./setting_definitions";
+import { BaseModule } from "base";
+import { GUI } from "./settingUtils";
 
 export abstract class GuiSubscreen {
     static START_X: number = 225;
     static START_Y: number = 125;
     static Y_MOD: number = 100;
+	readonly module: BaseModule;
 
-	constructor() {
+	constructor(module: BaseModule) {
+		this.module = module;
+
+		// create each handler for a new preference subscreen
 		SETTING_FUNC_NAMES.forEach(name => {
-			if (typeof (<any>this)[name] === "function")
-				(<any>window)[SETTING_FUNC_PREFIX + SETTING_NAME_PREFIX + this.constructor.name + name] = () => {
+			const fName = SETTING_FUNC_PREFIX + SETTING_NAME_PREFIX + this.name + name;
+			if (typeof (<any>this)[name] === "function" && typeof (<any>window)[fName] !== "function")
+				(<any>window)[fName] = () => {
 					(<any>this)[name]();
 				};
 		});
 	}
 
+	get name(): string {
+		throw "Override name in your subscreen class";
+	}
+
+	get icon(): string {
+		throw "Override icon in your subscreen class";
+	}
+
+	get label(): string {
+		throw "Override icon in your subscreen class";
+	}
+
+	get enabled(): boolean {
+		return true;
+	}
+
+	get message(): string {
+		return PreferenceMessage;
+	}
+
+	set message(s: string) {
+		PreferenceMessage = s;
+	}
+
     get SubscreenName(): string {
         return SETTING_NAME_PREFIX + this.constructor.name;  
-    } 
+    }
+
+	setSubscreen(screen: GuiSubscreen | string | null) {
+		return setSubscreen(screen);
+	}
 
     get settings(): BaseSettingsModel {
         Player.LSCG.GlobalModule = Player.LSCG.GlobalModule ?? { enabled: true };
         return Player.LSCG.GlobalModule
     }
 
+	get character(): Character {
+		// Because we're initialized by that instance, it must already exist
+		return GUI.instance?.currentCharacter as Character;
+	}
+
     getYPos(ix: number) {
         return GuiSubscreen.START_Y + (GuiSubscreen.Y_MOD * ix);
     }
 
 	Load() {
-        PreferenceSubscreen = this.SubscreenName;
-        PreferenceMessage = this.SubscreenName;
+        // Empty
 	}
 
 	Run() {
@@ -40,18 +79,11 @@ export abstract class GuiSubscreen {
 
 	Click() {
 		if (MouseIn(1815, 75, 90, 90)) return this.Exit();
-
-		// Enabled Checkbox
-		if (MouseIn(GuiSubscreen.START_X + 600, this.getYPos(1) - 32, 64, 64)){
-			this.settings.enabled = !this.settings.enabled;
-		}
 	}
 
 	Exit() {
-		// Empty
-		PreferenceMessage = "LSCG Main Menu";
-		PreferenceSubscreen = "LSCGMainMenu";
-        settingsSave();
+		setSubscreen("MainMenu");
+		settingsSave();
 	}
 
 	Unload() {

--- a/src/Settings/settingUtils.ts
+++ b/src/Settings/settingUtils.ts
@@ -4,6 +4,7 @@ import { GuiGlobal } from "./global";
 import { MainMenu } from "./mainmenu";
 import { SETTING_NAME_PREFIX, Subscreen } from "./setting_definitions";
 import { modules } from "modules";
+import { GlobalSettingsModel } from "./Models/base";
 
 export class GUI extends BaseModule {
 	static instance: GUI | null = null;
@@ -53,6 +54,14 @@ export class GUI extends BaseModule {
 		return GuiGlobal;
 	}
 
+	get settings(): GlobalSettingsModel {
+		return super.settings as GlobalSettingsModel;
+	}
+
+	get settingsStorage(): string | null {
+		return "GlobalModule";
+	}
+
 	constructor() {
 		super();
 		if (GUI.instance) {
@@ -66,6 +75,13 @@ export class GUI extends BaseModule {
 
 		GUI.instance = this;
 	}
+
+	get defaultSettings(): GlobalSettingsModel {
+		return {
+			enabled: true,
+			edgeBlur: false
+		};
+    }
 
 	load(): void {
 		// At that point all other modules have been initialized, build the list of their screens

--- a/src/Settings/settingUtils.ts
+++ b/src/Settings/settingUtils.ts
@@ -1,23 +1,14 @@
 import { BaseModule } from "../base";
-import { MainMenu, MAIN_MENU_ITEMS } from "./all";
 import { GuiSubscreen } from "./settingBase";
-
-export function getCurrentSubscreen(): GuiSubscreen | null {
-	return GUI.instance && GUI.instance.currentSubscreen;
-}
-
-export function setSubscreen(subscreen: GuiSubscreen | null): GuiSubscreen | null {
-	if (!GUI.instance) {
-		throw new Error("Attempt to set subscreen before init");
-	}
-	GUI.instance.currentSubscreen = subscreen;
-	return subscreen;
-}
+import { GuiGlobal } from "./global";
+import { MainMenu } from "./mainmenu";
+import { SETTING_NAME_PREFIX, Subscreen } from "./setting_definitions";
+import { modules } from "modules";
 
 export class GUI extends BaseModule {
 	static instance: GUI | null = null;
 
-	private _subscreens: GuiSubscreen[] | null = null;
+	private _subscreens: GuiSubscreen[];
 	private _mainMenu: MainMenu;
 	private _currentSubscreen: GuiSubscreen | null = null;
 
@@ -29,14 +20,37 @@ export class GUI extends BaseModule {
 		return this._currentSubscreen;
 	}
 
-	set currentSubscreen(subscreen: GuiSubscreen | null) {
+	set currentSubscreen(subscreen: GuiSubscreen | string | null) {
 		if (this._currentSubscreen) {
 			this._currentSubscreen.Unload();
 		}
-		this._currentSubscreen = subscreen;
+		if (typeof subscreen === "string") {
+			const scr = this._subscreens?.find(s => s.name === subscreen);
+			if (!scr) throw `Failed to find screen name ${subscreen}`;
+			this._currentSubscreen = scr;
+		} else {
+			this._currentSubscreen = subscreen;
+		}
+
+		// Reset that first, in case it gets set in the screen's Load callback
+		PreferenceMessage = "";
+
+		let subscreenName = "";
 		if (this._currentSubscreen) {
+			subscreenName = SETTING_NAME_PREFIX + this._currentSubscreen?.name;
 			this._currentSubscreen.Load();
 		}
+
+		// Get BC to render the new screen
+		PreferenceSubscreen = subscreenName;
+	}
+
+	get currentCharacter(): Character {
+		return Player;
+	}
+
+	get settingsScreen(): Subscreen | null {
+		return GuiGlobal;
 	}
 
 	constructor() {
@@ -45,18 +59,22 @@ export class GUI extends BaseModule {
 			throw new Error("Duplicate initialization");
 		}
 
-		this._mainMenu = new MainMenu(Player);
+		this._mainMenu = new MainMenu(this);
 		this._subscreens = [
 			this._mainMenu
 		];
-		MAIN_MENU_ITEMS.forEach(item => {
-			this._subscreens?.push(item.setting);
-		});
 
 		GUI.instance = this;
 	}
 
 	load(): void {
-		
+		// At that point all other modules have been initialized, build the list of their screens
+		for (const module of modules) {
+			if (!module.settingsScreen) continue;
+
+			this._subscreens.push(new module.settingsScreen(module));
+		}
+
+		this._mainMenu.subscreens = this._subscreens;
 	}
 }

--- a/src/Settings/setting_definitions.ts
+++ b/src/Settings/setting_definitions.ts
@@ -1,10 +1,6 @@
-import { ICONS } from "utils";
-import { GuiBoops } from "./boops";
-import { GuiCollar } from "./collar";
-import { GuiGlobal } from "./global";
-import { GuiHypno } from "./hypno";
-import { GuiLipstick } from "./lipstick";
+import { BaseModule } from "base";
 import { GuiSubscreen } from "./settingBase";
+import { GUI } from "./settingUtils";
 
 export const SETTING_FUNC_PREFIX: string = "PreferenceSubscreen";
 export const SETTING_NAME_PREFIX: string = "LSCG";
@@ -26,22 +22,16 @@ export enum ModuleCategory {
 	Misc = 99
 }
 
-export const SETTING_NAMES: Record<ModuleCategory, string> = {
-    [ModuleCategory.Global]: "General",
-    [ModuleCategory.Collar]: "Choke Collar",
-    [ModuleCategory.Hypno]: "Hypnosis",
-    [ModuleCategory.Boops]: "Boops",
-    [ModuleCategory.Lipstick]: "Lipstick",
-    [ModuleCategory.Activities]: "Activities",
-    [ModuleCategory.Misc]: "Miscellaneous"
-};
+export type Subscreen = (new (module: BaseModule) => GuiSubscreen);
 
-export const SETTING_ICONS: Record<ModuleCategory, string> = {
-    [ModuleCategory.Global]: ICONS.BDSM,//"Icons/General.png",
-    [ModuleCategory.Collar]: ICONS.COLLAR,// "Icons/Restriction.png",
-    [ModuleCategory.Hypno]: ICONS.HYPNO,//"Icons/Visibility.png",
-    [ModuleCategory.Boops]: "Icons/Use.png",
-    [ModuleCategory.Lipstick]: "Icons/Arousal.png",
-    [ModuleCategory.Activities]: "Icons/FriendList.png",
-    [ModuleCategory.Misc]: "Icons/General.png"
-};
+export function getCurrentSubscreen(): GuiSubscreen | null {
+	return GUI.instance && GUI.instance.currentSubscreen;
+}
+
+export function setSubscreen(subscreen: GuiSubscreen | string | null): GuiSubscreen | null {
+	if (!GUI.instance) {
+		throw new Error("Attempt to set subscreen before init");
+	}
+	GUI.instance.currentSubscreen = subscreen;
+	return GUI.instance.currentSubscreen;
+}

--- a/src/base.ts
+++ b/src/base.ts
@@ -6,19 +6,34 @@ export abstract class BaseModule {
 		return null;
 	};
 
+	/** Allows changing the subkey for that module settings storage */
+	get settingsStorage(): string | null {
+		return this.constructor.name;
+	}
+
 	get settings(): BaseSettingsModel {
-		(<any>Player.LSCG)[this.constructor.name] = (<any>Player.LSCG)[this.constructor.name] || {};
-		return (<any>Player.LSCG)[this.constructor.name];
+		if (!this.settingsStorage) return {} as BaseSettingsModel;
+		return (<any>Player.LSCG)[this.settingsStorage];
 	}
 
 	get Enabled(): boolean {
-		if (!Player.LSCG.GlobalModule)
-			Player.LSCG.GlobalModule = {enabled: true, edgeBlur: false};
 		return (Player.LSCG.GlobalModule.enabled && this.settings.enabled);
 	}
 
 	init() {
-		// Empty
+		this.registerDefaultSettings();
+	}
+
+	registerDefaultSettings(): void {
+		const storage = this.settingsStorage;
+		const defaults = this.defaultSettings;
+		if (!storage || !defaults) return;
+
+		(<any>Player.LSCG)[storage] = Object.assign(defaults, (<any>Player.LSCG)[storage] ?? {});
+	}
+
+	get defaultSettings(): BaseSettingsModel | null {
+		return null;
 	}
 
 	load() {

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,10 @@
 import { BaseSettingsModel } from "Settings/Models/base";
+import { Subscreen } from "Settings/setting_definitions";
 
 export abstract class BaseModule {
+	get settingsScreen() : Subscreen | null {
+		return null;
+	};
 
 	get settings(): BaseSettingsModel {
 		(<any>Player.LSCG)[this.constructor.name] = (<any>Player.LSCG)[this.constructor.name] || {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import { hookFunction, ICONS, isObject, settingsSave, VERSION } from './utils';
 import { modules, registerModule } from 'modules';
-import './modules';
 import { SettingsModel } from 'Settings/Models/settings';
 import { HypnoModule } from './Modules/hypno';
 import { CollarModule } from './Modules/collar';
@@ -57,7 +56,6 @@ export function init() {
 		delete (<any>Player.OnlineSettings).ClubGames;
 
     Player.LSCG = Player.OnlineSettings.LSCG || <SettingsModel>{};
-	settingsSave();
 
 	initSettingsScreen();
 
@@ -65,6 +63,8 @@ export function init() {
 		unload();
 		return;
 	}
+
+	settingsSave();
 
 	const currentAccount = Player.MemberNumber;
 	if (currentAccount == null) {
@@ -100,9 +100,11 @@ function init_modules(): boolean {
 	for (const m of modules) {
 		m.load();
 	}
+
 	for (const m of modules) {
 		m.run();
 	}
+
 	console.info("LSCG Modules Loaded.");
 	return true;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,14 @@
 import { hookFunction, ICONS, isObject, settingsSave, VERSION } from './utils';
-import { init_modules, unload_modules } from 'modules';
+import { modules, registerModule } from 'modules';
 import './modules';
 import { SettingsModel } from 'Settings/Models/settings';
+import { HypnoModule } from './Modules/hypno';
+import { CollarModule } from './Modules/collar';
+import { BoopsModule } from './Modules/boops';
+import { MiscModule } from './Modules/misc';
+import { LipstickModule } from './Modules/lipstick';
+import { GUI } from "Settings/settingUtils";
+import { ActivityModule } from "Modules/activities";
 
 function initWait() {
 	console.debug("BCX: Init wait");
@@ -27,7 +34,7 @@ export function loginInit(C: any) {
 	init();
 }
 
-export function initSettings() {
+export function initSettingsScreen() {
 	PreferenceSubscreenList.push("LSCGMainMenu");
 	hookFunction("TextGet", 2, (args: string[], next: (arg0: any) => any) => {
 		if (args[0] == "HomepageLSCGMainMenu") return "LSCG Settings";
@@ -43,7 +50,7 @@ export function init() {
 	if (window.LSCG_Loaded)
 		return;
 	
-		// clear any old settings.
+	// clear any old settings.
 	if (!!(<any>Player.OnlineSettings)?.LittleSera)
 		delete (<any>Player.OnlineSettings).LittleSera;
 	if (!!(<any>Player.OnlineSettings)?.ClubGames)
@@ -52,7 +59,7 @@ export function init() {
     Player.LSCG = Player.OnlineSettings.LSCG || <SettingsModel>{};
 	settingsSave();
 
-	initSettings();
+	initSettingsScreen();
 
 	if (!init_modules()) {
 		unload();
@@ -77,12 +84,41 @@ export function init() {
 	console.log(`LSCG loaded! Version: ${VERSION}`);
 }
 
+function init_modules(): boolean {
+	registerModule(new GUI());
+	registerModule(new HypnoModule());
+	registerModule(new CollarModule());
+	registerModule(new BoopsModule());
+	registerModule(new MiscModule());
+	registerModule(new LipstickModule());
+	registerModule(new ActivityModule());
+
+	for (const m of modules) {
+		m.init();
+	}
+
+	for (const m of modules) {
+		m.load();
+	}
+	for (const m of modules) {
+		m.run();
+	}
+	console.info("LSCG Modules Loaded.");
+	return true;
+}
+
 export function unload(): true {
 	unload_modules();
 
 	delete window.LSCG_Loaded;
 	console.log("LSCG: Unloaded.");
 	return true;
+}
+
+function unload_modules() {
+	for (const m of modules) {
+		m.unload();
+	}
 }
 
 initWait();

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,44 +1,9 @@
 import { BaseModule } from "base";
-import { HypnoModule } from './Modules/hypno';
-import { CollarModule } from './Modules/collar';
-import { BoopsModule } from './Modules/boops';
-import { MiscModule } from './Modules/misc';
-import { LipstickModule } from './Modules/lipstick';
-import { GUI } from "Settings/settingUtils";
-import { ActivityModule } from "Modules/activities";
 
-const modules: BaseModule[] = [];
+export const modules: BaseModule[] = [];
 
 export function registerModule<T extends BaseModule>(module: T): T {
 	modules.push(module);
 	return module;
 }
 
-export function init_modules(): boolean {
-	registerModule(new GUI());
-	registerModule(new HypnoModule());
-	registerModule(new CollarModule());
-	registerModule(new BoopsModule());
-	registerModule(new MiscModule());
-	registerModule(new LipstickModule());
-	registerModule(new ActivityModule());
-
-	for (const m of modules) {
-		m.init();
-	}
-
-	for (const m of modules) {
-		m.load();
-	}
-	for (const m of modules) {
-		m.run();
-	}
-	console.info("LSCG Modules Loaded.");
-	return true;
-}
-
-export function unload_modules() {
-	for (const m of modules) {
-		m.unload();
-	}
-}


### PR DESCRIPTION
This removes the hardcoded settings arrays in favor of each module registering its own screen (name, icon and title), and refactors the code so screen discovery and unloading is more streamlined (I needed the latter for `Unload()` to work correctly, but then ended up not needing it 🤷).

Then the registration of default settings is moved over to modules themselves instead of subscreens, removing all the duplication, and make the screens go through their respective module when accessing settings. Most of the getters are now just a passthrough from a screen to the abstract class, to its module, to the abstract class.

This fixes a crash where opening the General settings would crash, as it would only initialize its values but tried to access stuff in the Misc module.