### PR TITLE
Item use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ls-club-games",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ls-club-games",
-      "version": "1.0.0",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "bondage-club-mod-sdk": "^1.1.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -30,7 +30,7 @@ console.debug("LSCG: Parse start...");
       const git = simpleGit();
       console.log(await git.status());
       let LSCG_VERSION = packageJson.version;
-      await git.pull().tags((err, tags) => {
+      await git.tags((err, tags) => {
         if (!!tags.latest) {
           console.log('\nUsing tag version: %s\n', tags.latest);
           LSCG_VERSION = tags.latest;

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -12,8 +12,10 @@ import { ActivityBundle, ActivityModule, CustomAction, CustomPrerequisite } from
 import { HypnoModule } from "./hypno";
 import { MiscModule } from "./misc";
 
+type DrugType = "sedative" | "mindcontrol" | "horny" | "antidote";
+
 export interface DrugLevel {
-    type: "sedative" | "mindcontrol" | "horny";
+    type: DrugType;
     level: number;
     max: number;
 }
@@ -79,7 +81,7 @@ export class InjectorModule extends BaseModule {
     }
     
     safeword(): void {
-        this._doCure();
+        this.DoCure();
     }
 
     load(): void {
@@ -127,6 +129,9 @@ export class InjectorModule extends BaseModule {
             if (target == Player.MemberNumber && activityName == "Inject" && !!sender) {
                 var location = <AssetGroupItemName>data.Dictionary[2]?.FocusGroupName;
                 this.ProcessInjection(sender, location);
+            }
+            else if (target == Player.MemberNumber && activityName == "SipItem" && !!sender) {
+                this.ProcessDruggedDrink(sender);
             } else if (target == Player.MemberNumber) {
                 if (data.Content == "ChatOther-ItemNose-Pet" && this.settings.allowBoopRestore) {
                     if (this.asleep) this.Wake();
@@ -232,61 +237,62 @@ export class InjectorModule extends BaseModule {
                 CustomImage: "Assets/Female3DCG/ItemDevices/Preview/Net.png"
             });
 
-            this.activityModule.AddActivity({
-                Activity: <Activity>{
-                    Name: "ForceDrink",
-                    MaxProgress: 50,
-                    MaxProgressSelf: 50,
-                    Prerequisite: ["UseHands"]
-                },
-                Targets: [
-                    {
-                        Name: "ItemArms",
-                        SelfAllowed: true,
-                        TargetLabel: "Shoot Netgun",
-                        TargetAction: "SourceCharacter takes aim at TargetCharacter with their net gun.",
-                        TargetSelfAction: "SourceCharacter turns their netgun on themselves!"
-                    }
-                ],
-                CustomPrereqs: [
-                    {
-                        Name: "TargetCanDrink",
-                        Func: (acting, acted, group) => {
-                            // var mouthItems = [
-                            //     InventoryGet(acted, "ItemMouth"),
-                            //     InventoryGet(acted, "ItemMouth2"),
-                            //     InventoryGet(acted, "ItemMouth3"),
-                            // ].filter(g => !!g);
-                            // let stuffedGags = [
-                            //     "ClothStuffing",
-                            //     "PantyStuffing",
-                            //     "SockStuffing",
-                            //     "LargeDildo"
-                            // ];
-                            // let drankableGags = [
-                            //     ["LipGag"],
-                            //     ["RingGag"],
-                            //     ["SpiderGag"],
-                            //     ["FunnelGag", "Funnel"],
-                            //     ["DildoPlugGag", null],
-                            //     ["OTNPlugGag", null],
-                            //     ["DentalGag", null],
-                            //     ["PlugGag", null],
+            // this.activityModule.AddActivity({
+            //     Activity: <Activity>{
+            //         Name: "ForceDrink",
+            //         MaxProgress: 50,
+            //         MaxProgressSelf: 50,
+            //         Prerequisite: ["UseHands"]
+            //     },
+            //     Targets: [
+            //         {
+            //             Name: "ItemArms",
+            //             SelfAllowed: true,
+            //             TargetLabel: "Shoot Netgun",
+            //             TargetAction: "SourceCharacter takes aim at TargetCharacter with their net gun.",
+            //             TargetSelfAction: "SourceCharacter turns their netgun on themselves!"
+            //         }
+            //     ],
+            //     CustomPrereqs: [
+            //         {
+            //             Name: "TargetCanDrink",
+            //             Func: (acting, acted, group) => {
+            //                 // var mouthItems = [
+            //                 //     InventoryGet(acted, "ItemMouth"),
+            //                 //     InventoryGet(acted, "ItemMouth2"),
+            //                 //     InventoryGet(acted, "ItemMouth3"),
+            //                 // ].filter(g => !!g);
+            //                 // let stuffedGags = [
+            //                 //     "ClothStuffing",
+            //                 //     "PantyStuffing",
+            //                 //     "SockStuffing",
+            //                 //     "LargeDildo"
+            //                 // ];
+            //                 // let drankableGags = [
+            //                 //     ["LipGag"],
+            //                 //     ["RingGag"],
+            //                 //     ["SpiderGag"],
+            //                 //     ["FunnelGag", "Funnel"],
+            //                 //     ["DildoPlugGag", null],
+            //                 //     ["OTNPlugGag", null],
+            //                 //     ["DentalGag", null],
+            //                 //     ["PlugGag", null],
 
-                            // ];
-                            return this.GetGagDrinkAccess(acted) == "open" || this.GetGagDrinkAccess(acted) == "nothing";
-                        }
-                    }
-                ],
-                CustomAction: <CustomAction>{
-                    Func: (target, args, next) => {
-                        if (!target || this.GetGagDrinkAccess(target) == "blocked")
-                            return next(args);
-                        //this.gat
-                    }
-                },
-                CustomImage: "Assets/Female3DCG/ItemHandheld/Preview/GlassFilled.png"
-            });
+            //                 // ];
+                            
+            //                 return this.HoldingDruggedDrink(acting) && (this.GetGagDrinkAccess(acted) == "open" || this.GetGagDrinkAccess(acted) == "nothing");
+            //             }
+            //         }
+            //     ],
+            //     CustomAction: <CustomAction>{
+            //         Func: (target, args, next) => {
+            //             if (!target || this.GetGagDrinkAccess(target) == "blocked")
+            //                 return next(args);
+            //             this.TryForceDrink(target);
+            //         }
+            //     },
+            //     CustomImage: "Assets/Female3DCG/ItemHandheld/Preview/GlassFilled.png"
+            // });
         }        
 
         this.activityModule.AddCustomPrereq(<CustomPrerequisite>{
@@ -299,33 +305,6 @@ export class InjectorModule extends BaseModule {
 
     unload(): void {
         removeAllHooksByModule(ModuleCategory.Injector);
-    }
-
-    GetGagDrinkAccess(C: Character): GagDrinkAccess {
-        var mouthItems = [
-            InventoryGet(C, "ItemMouth"),
-            InventoryGet(C, "ItemMouth2"),
-            InventoryGet(C, "ItemMouth3"),
-        ].filter(g => !!g);
-        let gagOverrideAllowChecks = [
-            ["FunnelGag", "Funnel"]
-        ];
-
-        var overrideGag = mouthItems.find(gag => gagOverrideAllowChecks.map(o => o[0]).indexOf(gag?.Asset.Name!) > -1);
-        if (!!overrideGag) {
-            let check = gagOverrideAllowChecks.find(x => x[0] == overrideGag?.Asset.Name);
-            if (!!check && (check.length == 1 || check[1] == overrideGag.Property?.Type))
-                return "open";
-        }
-
-        let blocked = C.IsMouthBlocked();
-        let isOpen = C.IsMouthOpen();
-        if (blocked)
-            return "blocked";
-        else if (!blocked && isOpen)
-            return "open";
-        else
-            return "nothing";        
     }
 
     InitializeRestrictiveHooks() {
@@ -402,9 +381,11 @@ export class InjectorModule extends BaseModule {
             return next(args);
         }, ModuleCategory.Injector);
 
+        let _lastTick: number = CommonTime();
         hookFunction('TimerProcess', 1, (args, next) => {
-            if (ActivityAllowed() && this.hornyLevel > 0 && this.hornyLastBumped + this.settings.hornyTickTime < CurrentTime) {
-                this.hornyLastBumped = CurrentTime;
+            let now = CommonTime();
+            if (ActivityAllowed() && this.hornyLevel > 0 && this.hornyLastBumped + this.settings.hornyTickTime < now) {
+                this.hornyLastBumped = now;
                 var newProgress = (Player.ArousalSettings?.Progress ?? 0) + (this.hornyLevel/this.drugLevelMultiplier) * 4;
                 newProgress = Math.min(99, newProgress);
                 if (getRandomInt(this.hornyLevelMax) <= Math.floor(this.hornyLevel/this.drugLevelMultiplier)) {
@@ -413,6 +394,10 @@ export class InjectorModule extends BaseModule {
                 }
                 ActivitySetArousal(Player, newProgress);
             }
+            // if (_lastTick + 400 < now) {
+            //     _lastTick = now;
+            //     this.ProcessGradualLevels();
+            // }
             return next(args);
         }, ModuleCategory.Injector);
 
@@ -462,6 +447,13 @@ export class InjectorModule extends BaseModule {
     get hornyLevelMax(): number {return this.settings.hornyLevelMax};
     set hornyLevelMax(val: number) {if (this.settings.hornyLevelMax != val) {this.settings.hornyLevelMax = val; settingsSave(true);}}
 
+    _targetSedativeLevel: number = 0;
+    get targetSedativeLevel(): number {return Math.max(this.sedativeLevel, this._targetSedativeLevel)};
+    _targetMindControlLevel: number = 0;
+    get targetMindControlLevel(): number {return Math.max(this.mindControlLevel, this._targetMindControlLevel)};
+    _targetHornyLevel: number = 0;
+    get targetHornyLevel(): number {return Math.max(this.hornyLevel, this._targetHornyLevel)};
+
     sedativeCooldownInterval: number = 0;
     mindControlCooldownInterval: number = 0;
     hornyCooldownInterval: number = 0;
@@ -470,49 +462,97 @@ export class InjectorModule extends BaseModule {
 
     InjectionLocationTable: Map<string, number> = new Map<string, number>(Object.entries(locationObj))
 
+    GetDrugTypes(item: CraftingItem): DrugType[] {
+        var name = item.Name;
+        var description = item.Description;
+        var totalString = name + " | " + description;
+
+        var types: DrugType[] = [];
+
+        if (this.settings.sedativeKeywords?.some(ph => isPhraseInString(totalString, ph)))
+            types.push("sedative");
+        if (this.settings.mindControlKeywords?.some(ph => isPhraseInString(totalString, ph)))
+            types.push("mindcontrol");
+        if (this.settings.hornyKeywords?.some(ph => isPhraseInString(totalString, ph)))
+            types.push("horny");
+        if (this.settings.cureKeywords?.some(ph => isPhraseInString(totalString, ph)))
+            types.push("antidote");
+
+        return types;
+    }
+
+    ProcessDruggedDrink(sender: Character) {
+        var asset = InventoryGet(sender, "ItemHandheld");
+        if (!asset?.Craft)
+            return;
+        let types = this.GetDrugTypes(asset.Craft!);
+        if (types.indexOf("sedative") > -1 && this.settings.enableSedative)
+            this.DrinkSedative(sender);
+        if (types.indexOf("mindcontrol") > -1 && this.settings.enableMindControl)
+            this.DrinkMindContrll(sender);
+        if (types.indexOf("horny") > -1 && this.settings.enableHorny)
+            this.DrinkHorny(sender);
+        if (types.indexOf("antidote") > -1)
+            this.DrinkCure(sender);
+    }
+
     ProcessInjection(sender: Character, location: AssetGroupItemName) {
         var asset = InventoryGet(sender, "ItemHandheld");
         if (!asset?.Craft)
             return;
+
+        let types = this.GetDrugTypes(asset.Craft!);
         
-        var name = asset.Craft.Name;
-        var description = asset.Craft.Description;
-        var totalString = name + " | " + description;
-
-        var isSedative = this.settings.sedativeKeywords?.some(ph => isPhraseInString(totalString, ph));
-        var isMindControl = this.settings.mindControlKeywords?.some(ph => isPhraseInString(totalString, ph));
-        var isHorny = this.settings.hornyKeywords?.some(ph => isPhraseInString(totalString, ph));
-        var isCure = this.settings.cureKeywords?.some(ph => isPhraseInString(totalString, ph));
-
-        if (!AudioShouldSilenceSound(true))
+        if (!AudioShouldSilenceSound(true) && types.length > 0)
             AudioPlayInstantSound(AUDIO.INJECTION, getPlayerVolume(0));
 
-        if (isSedative && this.settings.enableSedative)
+        if (types.indexOf("sedative") > -1 && this.settings.enableSedative)
             this.InjectSedative(sender, location);
-        if (isMindControl && this.settings.enableMindControl)
+        if (types.indexOf("mindcontrol") > -1 && this.settings.enableMindControl)
             this.InjectMindControl(sender, location);
-        if (isHorny && this.settings.enableHorny)
+        if (types.indexOf("horny") > -1 && this.settings.enableHorny)
             this.InjectHorny(sender, location);
-        if (isCure)
+        if (types.indexOf("antidote") > -1)
             this.InjectCure(sender, location);
     }
 
     sedativeInjectStr = [
-        "%NAME% sighs as a cool relaxing calm glides through %POSSESSIVE% body, fighting to keep %POSSESSIVE% eyes open.",
-        "%NAME%'s muscle relax as %OPP_NAME%'s sedative courses through %POSSESSIVE% body",
+        "%NAME% gulps and swallows %OPP_NAME%'s drink, a cool relaxing feeling starting to spread through %POSSESSIVE% body.",
+        "%NAME%'s muscle relax as %OPP_NAME%'s sedative courses through %POSSESSIVE% body.",
         "%NAME% fights to stay conscious against the relentless weight of %OPP_NAME%'s drug."
-    ];    
+    ];
 
-    InjectSedative(sender: Character, location: AssetGroupItemName) {
-        var additive = this.drugLevelMultiplier * (this.InjectionLocationTable.get(location) ?? 1)
-        this.sedativeLevel = Math.min(this.sedativeLevel + additive, this.sedativeMax * this.drugLevelMultiplier);
-        SendAction(this.sedativeInjectStr[getRandomInt(this.sedativeInjectStr.length)], sender);
-        DrawFlashScreen("#5C5CFF", 1000, this.sedativeLevel * 2);
+    sedativeDrinkStr = [
+        "%NAME% sighs as a cool relaxing calm glides down %POSSESSIVE% throat, fighting to keep %POSSESSIVE% eyes open.",
+        "%NAME%'s muscle relax as %OPP_NAME%'s sedative pours down %POSSESSIVE% throat and starts to take effect.",
+        "%NAME%'s eyes droop as %POSSESSIVE% fights to stay conscious against the cool, welcoming weight of %OPP_NAME%'s drug."
+    ];
+
+    AddSedative(multiplier: number, gradual: boolean = false) {
+        var additive = this.drugLevelMultiplier * multiplier;
+        var newLevel = Math.min(this.sedativeLevel + additive, this.sedativeMax * this.drugLevelMultiplier);
+        // if (gradual)
+        //     this._targetSedativeLevel = newLevel;
+        // else
+        this.sedativeLevel = newLevel;
 
         if (!this.asleep) {
             MiniGameStart(this.sleepyGame.name, ((this.sedativeLevel / this.drugLevelMultiplier) * 8), "LSCG_InjectEnd_Sedative");
         }
         CurrentModule = "Online";
+    }
+
+    DrinkSedative(sender: Character) {
+        this.AddSedative(2, true);
+        SendAction(this.sedativeDrinkStr[getRandomInt(this.sedativeDrinkStr.length)], sender);
+    }
+
+    InjectSedative(sender: Character, location: AssetGroupItemName) {
+        this.AddSedative(this.InjectionLocationTable.get(location) ?? 1);
+        SendAction(this.sedativeInjectStr[getRandomInt(this.sedativeInjectStr.length)], sender);
+        DrawFlashScreen("#5C5CFF", 1000, this.sedativeLevel * 2);
+
+        
     }
 
     brainwashInjectStr = [
@@ -521,16 +561,35 @@ export class InjectorModule extends BaseModule {
         "%NAME%'s eyes struggle to focus as %OPP_NAME%'s drug makes %POSSESSIVE% more suggestable."
     ];
 
-    InjectMindControl(sender: Character, location: AssetGroupItemName) {
-        var additive = this.drugLevelMultiplier * (this.InjectionLocationTable.get(location) ?? 1)
-        this.mindControlLevel = Math.min(this.mindControlLevel + additive, this.mindControlMax * this.drugLevelMultiplier);
-        SendAction(this.brainwashInjectStr[getRandomInt(this.brainwashInjectStr.length)], sender);
-        DrawFlashScreen("#A020F0", 1000, this.mindControlLevel * 2);
+    brainwashDrinkStr = [
+        "%NAME% starts to drift dreamily as they swallow %OPP_NAME%'s drink.",
+        "%NAME% gasps weakly and starts to lose focus as %OPP_NAME%'s drug warms %POSSESSIVE% comfortably.",
+        "%NAME%'s eyes flutter and unfocus as %OPP_NAME%'s drink slides warmly down %POSSESSIVE% throat."
+    ];
+
+    AddMindControl(multiplier: number, gradual: boolean = false) {
+        var additive = this.drugLevelMultiplier * multiplier
+        var newLevel = Math.min(this.mindControlLevel + additive, this.mindControlMax * this.drugLevelMultiplier);
+        // if (gradual)
+        //     this._targetMindControlLevel = newLevel;
+        // else
+        this.mindControlLevel = newLevel;
 
         if (!this.brainwashed) {
             MiniGameStart(this.brainWashGame.name, ((this.mindControlLevel / this.drugLevelMultiplier) * 8), "LSCG_InjectEnd_Brainwash");
         }
         CurrentModule = "Online";
+    }
+
+    DrinkMindContrll(sender: Character) {
+        this.AddMindControl(2, true);
+        SendAction(this.brainwashDrinkStr[getRandomInt(this.brainwashDrinkStr.length)], sender);
+    }
+
+    InjectMindControl(sender: Character, location: AssetGroupItemName) {
+        this.AddMindControl(this.InjectionLocationTable.get(location) ?? 1);
+        SendAction(this.brainwashInjectStr[getRandomInt(this.brainwashInjectStr.length)], sender);
+        DrawFlashScreen("#A020F0", 1000, this.mindControlLevel * 2);
     }
 
     hornyInjectStr = [
@@ -539,22 +598,39 @@ export class InjectorModule extends BaseModule {
         "%NAME% quivers as %POSSESSIVE% body is flooded with %OPP_NAME%'s aphrodisiac." 
     ];
 
-    InjectHorny(sender: Character, location: AssetGroupItemName) {
-        var additive = this.drugLevelMultiplier * (this.InjectionLocationTable.get(location) ?? 1)
+    hornyDrinkStr = [
+        "%NAME% lets out a long low moan as %OPP_NAME%'s drink burns pleasurably down their throat.",
+        "%NAME%'s eyes roll back as a wave of pleasure eminates from %POSSESSIVE% belly.",
+        "%NAME% gulps and quivers as %POSSESSIVE% body is slowly flooded with %OPP_NAME%'s aphrodisiac." 
+    ];
+
+    AddHorny(multiplier: number, gradual: boolean = false) {
+        var additive = this.drugLevelMultiplier * multiplier
         let newLevelActual = this.hornyLevel + additive;
+        // if (gradual)
+        //     this._targetHornyLevel = newLevelActual;
+        // else {
         this.hornyLevel = Math.min(newLevelActual, this.hornyLevelMax * this.drugLevelMultiplier);
-        
-        SendAction(this.hornyInjectStr[getRandomInt(this.hornyInjectStr.length)], sender);
-        DrawFlashScreen("#FF647F", 1000, this.hornyLevel * 2);
-        
         if (newLevelActual >= this.hornyLevelMax * this.drugLevelMultiplier && Player.ArousalSettings?.Progress! > 50) {
             ActivityOrgasmPrepare(Player);
             this.hornyLevel -= this.drugLevelMultiplier;
-        }
+            }
+        //}
 
         if (!!(<any>Player).BCT?.splitOrgasmArousal?.arousalProgress) {
             (<any>Player).BCT.splitOrgasmArousal.arousalProgress = 100;
         }
+    }
+
+    DrinkHorny(sender: Character) {
+        this.AddHorny(2);
+        SendAction(this.hornyDrinkStr[getRandomInt(this.hornyDrinkStr.length)], sender);
+    }
+
+    InjectHorny(sender: Character, location: AssetGroupItemName) {
+        this.AddHorny(this.InjectionLocationTable.get(location) ?? 1);
+        SendAction(this.hornyInjectStr[getRandomInt(this.hornyInjectStr.length)], sender);
+        DrawFlashScreen("#FF647F", 1000, this.hornyLevel * 2);
     }
 
     cureInjectStr = [
@@ -563,12 +639,23 @@ export class InjectorModule extends BaseModule {
         "%OPP_NAME%'s drug rushes warmly through %NAME%'s body, curing what ailes %POSSESSIVE%." 
     ];
 
-    InjectCure(sender: Character, location: AssetGroupItemName) {
-        SendAction(this.cureInjectStr[getRandomInt(this.cureInjectStr.length)], sender);
-        this._doCure();
+    cureDrinkStr = [
+        "%NAME% gulps thankfully as %OPP_NAME%'s medicine slowly heals %POSSESSIVE%.",
+        "%NAME%'s body glows slightly as %OPP_NAME%'s cure glides warmly through %POSSESSIVE%.",
+        "%OPP_NAME%'s antidote slowly washes through %NAME%'s body, curing what ailes %POSSESSIVE%." 
+    ];
+
+    DrinkCure(sender: Character) {
+        SendAction(this.cureDrinkStr[getRandomInt(this.cureDrinkStr.length)], sender);
+        this.DoCure();
     }
 
-    _doCure() {
+    InjectCure(sender: Character, location: AssetGroupItemName) {
+        SendAction(this.cureInjectStr[getRandomInt(this.cureInjectStr.length)], sender);
+        this.DoCure();
+    }
+
+    DoCure(gradual: boolean = false) {
         this.sedativeLevel = 0;
         this.mindControlLevel = 0;
         this.hornyLevel = 0;
@@ -756,6 +843,89 @@ export class InjectorModule extends BaseModule {
             DrawRect(barX, barY + (Math.round((100 - barProgress) * 4 * barZoom)), (40 * barZoom), (Math.round(barProgress * 4 * barZoom)), color);
             DrawEmptyRect(barX, barY, (40 * barZoom), (Math.round(400 * barZoom)), color);
         });
+    }
+
+    ProcessGradualLevels() {
+        if (this._targetHornyLevel > 0){
+            if (this.targetHornyLevel > this.hornyLevel) {
+                let newHorny = Math.max(this.targetHornyLevel, this.hornyLevel + this.drugLevelMultiplier / 10);
+                if (newHorny > this.hornyLevelMax * this.drugLevelMultiplier && Player.ArousalSettings?.Progress! > 50) {
+                    ActivityOrgasmPrepare(Player);
+                    this.hornyLevel -= this.drugLevelMultiplier;
+                    this._targetHornyLevel = 0;
+                }
+                this.hornyLevel = newHorny;
+            }
+            else
+                this._targetHornyLevel = 0;
+        }
+
+        if (this._targetMindControlLevel > 0){
+            if (this.targetMindControlLevel > this.mindControlLevel) {
+                this.mindControlLevel = Math.max(this.targetMindControlLevel, this.mindControlLevel + this.drugLevelMultiplier / 10);
+                if (this.mindControlLevel == this.targetMindControlLevel) {
+                    if (!this.brainwashed) {
+                        MiniGameStart(this.brainWashGame.name, ((this.mindControlLevel / this.drugLevelMultiplier) * 8), "LSCG_InjectEnd_Brainwash");
+                    }
+                    CurrentModule = "Online";
+                }
+            }
+            else
+                this._targetMindControlLevel = 0;
+        }
+
+        if (this._targetSedativeLevel > 0){
+            if (this.targetSedativeLevel > this.sedativeLevel) {
+                this.sedativeLevel = Math.max(this.targetSedativeLevel, this.sedativeLevel + this.drugLevelMultiplier / 10);
+                if (this.sedativeLevel == this.targetSedativeLevel) {
+                    if (!this.asleep) {
+                        MiniGameStart(this.sleepyGame.name, ((this.sedativeLevel / this.drugLevelMultiplier) * 8), "LSCG_InjectEnd_Sedative");
+                    }
+                    CurrentModule = "Online";
+                }
+            }
+            else
+                this._targetSedativeLevel = 0;
+        }
+    }
+
+    HoldingDruggedDrink(C: Character): boolean {
+        var item = InventoryGet(C, "Handheld");
+        if (!item || (item.Asset.Name != "GlassFilled" && item.Asset.Name != "Mug") || !item.Craft)
+            return false;
+        var drugTypes = this.GetDrugTypes(item.Craft!);
+        return drugTypes.length > 0;
+    }
+
+    GetGagDrinkAccess(C: Character): GagDrinkAccess {
+        var mouthItems = [
+            InventoryGet(C, "ItemMouth"),
+            InventoryGet(C, "ItemMouth2"),
+            InventoryGet(C, "ItemMouth3"),
+        ].filter(g => !!g);
+        let gagOverrideAllowChecks = [
+            ["FunnelGag", "Funnel"]
+        ];
+
+        var overrideGag = mouthItems.find(gag => gagOverrideAllowChecks.map(o => o[0]).indexOf(gag?.Asset.Name!) > -1);
+        if (!!overrideGag) {
+            let check = gagOverrideAllowChecks.find(x => x[0] == overrideGag?.Asset.Name);
+            if (!!check && (check.length == 1 || check[1] == overrideGag.Property?.Type))
+                return "open";
+        }
+
+        let blocked = C.IsMouthBlocked();
+        let isOpen = C.IsMouthOpen();
+        if (blocked)
+            return "blocked";
+        else if (!blocked && isOpen)
+            return "open";
+        else
+            return "nothing";        
+    }
+
+    TryForceDrink(target: Character) {
+        
     }
 }
 

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1,0 +1,126 @@
+import { BaseModule } from "base";
+import { getModule } from "modules";
+import { GuiHypno } from "Settings/hypno";
+import { MainMenu } from "Settings/mainmenu";
+import { RemoteMainMenu } from "Settings/Remote/mainmenu";
+import { RemoteGuiSubscreen } from "Settings/Remote/remoteBase";
+import { GuiSubscreen } from "Settings/settingBase";
+import { GUI } from "Settings/settingUtils";
+import { ModuleCategory } from "Settings/setting_definitions";
+import { getCharacter, hookFunction, ICONS, removeAllHooksByModule } from "../utils";
+import { ActivityBundle, ActivityModule, ActivityTarget } from "./activities";
+import { HypnoModule } from "./hypno";
+
+// Remote UI Module to handle configuration on other characters
+// Can be used to "program" another character's hypnosis, collar, etc.
+// Framework inspired from BCX
+export class ItemUseModule extends BaseModule {   
+	activities: ActivityModule | undefined;
+
+    load(): void {
+        
+    }
+
+	run(): void {
+		this.activities = getModule<ActivityModule>("ActivityModule")
+
+		this.activities.AddActivity(<ActivityBundle>{
+			Activity: <Activity>{
+				Name: "UseBallgag",
+				MaxProgress: 50,
+				MaxProgressSelf: 80,
+				Prerequisite: ["ZoneAccessible", "ZoneNaked", "UseHands"]
+			},
+			Targets: [
+				<ActivityTarget>{
+					Name: "ItemMouth",
+					TargetLabel: "Gag Mouth",
+					TargetAction: "SourceCharacter pushes PronounPossessive gag into TargetCharacter's mouth, latching it behind their head.",
+					TargetSelfAction: "SourceCharacter gags themselves.",
+					SelfAllowed: true
+				}
+			],
+			CustomPrereqs: [
+				{
+					Name: "HoldingBallgag",
+					Func: (acting, acted, group) => {
+						return InventoryGet(acting, "ItemHandheld")?.Asset.Name! == "Ballgag";
+					}
+				}
+			],
+			CustomAction: {
+				Func: (target, args, next) => {
+					if (!target)
+						return;
+					var location = args[1]?.Dictionary[2]?.FocusGroupName;
+					var gag = InventoryGet(Player, "ItemHandheld");
+					InventoryRemove(Player, "ItemHandheld", true);
+					this.ApplyGag(target, location, gag)
+					return next(args);
+				}
+			},
+			CustomImage: "Assets/Female3DCG/ItemMouth/Preview/BallGag.png"
+		})
+
+		this.activities.AddActivity(<ActivityBundle>{
+			Activity: <Activity>{
+				Name: "TakeBallgag",
+				MaxProgress: 50,
+				MaxProgressSelf: 80,
+				Prerequisite: ["UseHands"]
+			},
+			Targets: [
+				<ActivityTarget>{
+					Name: "ItemMouth",
+					TargetLabel: "Take Gag",
+					TargetAction: "SourceCharacter unlatches and removes TargetCharacter's ballgag.",
+					TargetSelfAction: "SourceCharacter pulls the ballgag out of PronounPossessive mouth.",
+					SelfAllowed: true
+				}
+			],
+			CustomPrereqs: [
+				{
+					Name: "Ballgagged",
+					Func: (acting, acted, group) => {
+						return InventoryGet(acted, group.Name)?.Asset.Name! == "BallGag";
+					}
+				}
+			],
+			CustomAction: {
+				Func: (target, args, next) => {
+					if (!target)
+						return;
+					var location = args[1]?.Dictionary[2]?.FocusGroupName;
+					this.TakeGag(target, location);
+					return next(args);
+				}
+			},
+			CustomImage: "Assets/Female3DCG/ItemMouth/Preview/BallGag.png"
+		})
+	}
+
+    unload(): void {
+        removeAllHooksByModule(ModuleCategory.ItemUse);
+    }
+
+	ApplyGag(target: Character, location: string, gagItem: Item | null) {
+        var gag = InventoryWear(target, "BallGag", location, gagItem?.Color, undefined, Player.MemberNumber, gagItem?.Craft, true);
+		gag!.Property!.Type = "Tight";
+		setTimeout(() => ChatRoomCharacterItemUpdate(target, location));
+    }
+
+	TakeGag(target: Character, location: string) {
+		var gag = InventoryGet(target, location);
+		var existingHand = InventoryGet(Player, "ItemHandheld");
+		if (!gag || !!existingHand)
+			return;
+		var validParams = ValidationCreateDiffParams(target, Player.MemberNumber!);
+		if (ValidationCanRemoveItem(gag!, validParams, false)) {
+			InventoryRemove(target, location, true);
+			var craft = gag.Craft;
+			craft!.Lock = "";
+			InventoryWear(Player, "Ballgag", "ItemHandheld", gag.Color, undefined, Player.MemberNumber, craft, true);
+			setTimeout(() => ChatRoomCharacterItemUpdate(target, location));
+		}
+	}
+}

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -7,15 +7,19 @@ import { RemoteGuiSubscreen } from "Settings/Remote/remoteBase";
 import { GuiSubscreen } from "Settings/settingBase";
 import { GUI } from "Settings/settingUtils";
 import { ModuleCategory } from "Settings/setting_definitions";
-import { getCharacter, hookFunction, ICONS, removeAllHooksByModule } from "../utils";
+import { getCharacter, getRandomInt, hookFunction, ICONS, removeAllHooksByModule, SendAction } from "../utils";
 import { ActivityBundle, ActivityModule, ActivityTarget } from "./activities";
+import { BoopsModule } from "./boops";
 import { HypnoModule } from "./hypno";
+import { InjectorModule } from "./injector";
+import { MiscModule } from "./misc";
 
 // Remote UI Module to handle configuration on other characters
 // Can be used to "program" another character's hypnosis, collar, etc.
 // Framework inspired from BCX
 export class ItemUseModule extends BaseModule {   
 	activities: ActivityModule | undefined;
+	failedStealTime: number = 0;
 
     load(): void {
         
@@ -24,6 +28,7 @@ export class ItemUseModule extends BaseModule {
 	run(): void {
 		this.activities = getModule<ActivityModule>("ActivityModule")
 
+		// Ballgag Mouth
 		this.activities.AddActivity(<ActivityBundle>{
 			Activity: <Activity>{
 				Name: "UseBallgag",
@@ -52,16 +57,15 @@ export class ItemUseModule extends BaseModule {
 				Func: (target, args, next) => {
 					if (!target)
 						return;
-					var location = args[1]?.Dictionary[2]?.FocusGroupName;
-					var gag = InventoryGet(Player, "ItemHandheld");
-					InventoryRemove(Player, "ItemHandheld", true);
-					this.ApplyGag(target, location, gag)
+					var location = target.FocusGroup?.Name!;
+					this.ApplyGag(target, Player, "Ballgag", "BallGag", location)
 					return next(args);
 				}
 			},
 			CustomImage: "Assets/Female3DCG/ItemMouth/Preview/BallGag.png"
-		})
+		});
 
+		// Take Ballgag
 		this.activities.AddActivity(<ActivityBundle>{
 			Activity: <Activity>{
 				Name: "TakeBallgag",
@@ -82,7 +86,8 @@ export class ItemUseModule extends BaseModule {
 				{
 					Name: "Ballgagged",
 					Func: (acting, acted, group) => {
-						return InventoryGet(acted, group.Name)?.Asset.Name! == "BallGag";
+						var location = acted.FocusGroup?.Name!;
+						return !InventoryGet(acting, "ItemHandheld") && InventoryGet(acted, location)?.Asset.Name! == "BallGag";
 					}
 				}
 			],
@@ -90,37 +95,282 @@ export class ItemUseModule extends BaseModule {
 				Func: (target, args, next) => {
 					if (!target)
 						return;
-					var location = args[1]?.Dictionary[2]?.FocusGroupName;
-					this.TakeGag(target, location);
+					var location = target.FocusGroup?.Name!;
+					this.TakeGag(target, Player, "Ballgag", "BallGag", location);
 					return next(args);
 				}
 			},
 			CustomImage: "Assets/Female3DCG/ItemMouth/Preview/BallGag.png"
-		})
+		});
+
+		// Gag Mouth with Panties
+		this.activities.AddActivity(<ActivityBundle>{
+			Activity: <Activity>{
+				Name: "UsePanties",
+				MaxProgress: 50,
+				MaxProgressSelf: 80,
+				Prerequisite: ["ZoneAccessible", "ZoneNaked", "UseHands"]
+			},
+			Targets: [
+				<ActivityTarget>{
+					Name: "ItemMouth",
+					TargetLabel: "Gag Mouth",
+					TargetAction: "SourceCharacter stuffs PronounPossessive panties into TargetCharacter's mouth, filling it.",
+					TargetSelfAction: "SourceCharacter stuffs PronounPossessive panties into PronounPossessive own mouth.",
+					SelfAllowed: true
+				}
+			],
+			CustomPrereqs: [
+				{
+					Name: "HoldingPanties",
+					Func: (acting, acted, group) => {
+						return InventoryGet(acting, "ItemHandheld")?.Asset.Name! == "Panties";
+					}
+				}
+			],
+			CustomAction: {
+				Func: (target, args, next) => {
+					if (!target)
+						return;
+					var location = target.FocusGroup?.Name!;
+					this.ApplyGag(target, Player, "Panties", "PantyStuffing", location);
+					return next(args);
+				}
+			},
+			CustomImage: "Assets/Female3DCG/ItemMouth/Preview/PantyStuffing.png"
+		});
+
+		// Take Panties
+		this.activities.AddActivity(<ActivityBundle>{
+			Activity: <Activity>{
+				Name: "TakePanties",
+				MaxProgress: 50,
+				MaxProgressSelf: 80,
+				Prerequisite: ["UseHands"]
+			},
+			Targets: [
+				<ActivityTarget>{
+					Name: "ItemMouth",
+					TargetLabel: "Take Gag",
+					TargetAction: "SourceCharacter takes the panty stuffing from TargetCharacter's mouth.",
+					TargetSelfAction: "SourceCharacter pulls the panties out of PronounPossessive own mouth.",
+					SelfAllowed: true
+				}
+			],
+			CustomPrereqs: [
+				{
+					Name: "PantyStuffed",
+					Func: (acting, acted, group) => {
+						var location = acted.FocusGroup?.Name!;
+						return !InventoryGet(acting, "ItemHandheld") && InventoryGet(acted, location)?.Asset.Name! == "PantyStuffing";
+					}
+				}
+			],
+			CustomAction: {
+				Func: (target, args, next) => {
+					if (!target)
+						return;
+					var location = target.FocusGroup?.Name!;
+					this.TakeGag(target, Player, "Panties", "PantyStuffing", location);
+					return next(args);
+				}
+			},
+			CustomImage: "Assets/Female3DCG/ItemMouth/Preview/PantyStuffing.png"
+		});
+
+		// Tie Up
+		this.activities.AddActivity(<ActivityBundle>{
+			Activity: <Activity>{
+				Name: "TieUp",
+				MaxProgress: 50,
+				MaxProgressSelf: 80,
+				Prerequisite: ["UseHands", "ZoneAccessible"]
+			},
+			Targets: this.GetHempRopeLocations().map(loc => <ActivityTarget>{
+						Name: loc,
+						TargetLabel: "Tie Up",
+						TargetAction: `SourceCharacter swiftly wraps PronounPossessive rope around TargetCharacter's ${loc.substring(4).toLocaleLowerCase()}, binding TargetPronounPossessive tightly.`
+					}),
+			// 	<ActivityTarget>{
+			// 		Name: "ItemArms",
+			// 		TargetLabel: "Tie Up",
+			// 		TargetAction: "SourceCharacter swiftly wraps PronounPossessive rope around TargetCharacter's arms and torso, binding TargetPronounPossessive tightly."
+			// 	}
+			// ],
+			CustomPrereqs: [
+				{
+					Name: "HasCoiledRope",
+					Func: (acting, acted, group) => {
+						var location = acted.FocusGroup?.Name!;
+						return InventoryGet(acting, "ItemHandheld")?.Asset.Name.startsWith("RopeCoil") && !InventoryGet(acted, location);
+					}
+				}
+			],
+			CustomAction: {
+				Func: (target, args, next) => {
+					if (!target)
+						return;
+					var location = target.FocusGroup?.Name!;
+					this.TieUp(target, Player, location);
+					return next(args);
+				}
+			},
+			CustomImage: "Assets/Female3DCG/ItemArms/Preview/HempRope.png"
+		});
+
+		// Steal
+		this.activities.AddActivity(<ActivityBundle>{
+			Activity: <Activity>{
+				Name: "Steal",
+				MaxProgress: 50,
+				MaxProgressSelf: 50,
+				Prerequisite: ["UseHands", "ZoneAccessible"]
+			},
+			Targets: [
+				<ActivityTarget>{
+					Name: "ItemHands",
+					TargetLabel: "Steal!",
+					TargetAction: "SourceCharacter grabs at TargetCharacters hands, trying to steal TargetPronounPossessive item!",
+					SelfAllowed: false
+				}
+			],
+			CustomPrereqs: [
+				{
+					Name: "CanSteal",
+					Func: (acting, acted, group) => {
+						if (acted.FocusGroup?.Name != "ItemHandheld")
+							return false;
+						var item = InventoryGet(acted, "ItemHandheld");
+						if (!item)
+							return false;
+						var OnCooldown = this.failedStealTime > 0 && (this.failedStealTime + 60000) > CommonTime(); // 1 minute cooldown on steal attempts.
+						var validParams = ValidationCreateDiffParams(acted, acting.MemberNumber!);
+						var allowed = ValidationCanRemoveItem(item!, validParams, false);
+						return !OnCooldown && allowed && !InventoryGet(acting, "ItemHandheld");
+					}
+				}
+			],
+			CustomAction: {
+				Func: (target, args, next) => {
+					if (!target)
+						return;
+					this.TrySteal(target, Player, InventoryGet(target, "ItemHandheld")!);
+				}
+			},
+			CustomImage: "Assets/Female3DCG/ItemArms/Preview/HempRope.png"
+		});
 	}
 
     unload(): void {
         removeAllHooksByModule(ModuleCategory.ItemUse);
     }
 
-	ApplyGag(target: Character, location: string, gagItem: Item | null) {
-        var gag = InventoryWear(target, "BallGag", location, gagItem?.Color, undefined, Player.MemberNumber, gagItem?.Craft, true);
-		gag!.Property!.Type = "Tight";
-		setTimeout(() => ChatRoomCharacterItemUpdate(target, location));
+	GetHempRopeLocations(): string[] {
+		return AssetFemale3DCG.filter(g => g.Asset.some(a => (a as AssetDefinition)?.Name == "HempRope")).map(g => g.Group);
+	}
+
+	ApplyGag(target: Character, source: Character, handItemName: string, gagItemName: string, location: string) {
+		var gagItem = InventoryGet(source, "ItemHandheld");
+		if (gagItem?.Asset.Name == handItemName) {
+			InventoryRemove(source, "ItemHandheld", true);
+			var gag = InventoryWear(target, gagItemName, location, gagItem?.Color, undefined, source.MemberNumber, gagItem?.Craft, true);
+			if (gagItemName == "BallGag")
+				gag!.Property!.Type = "Tight";
+			setTimeout(() => ChatRoomCharacterItemUpdate(target, location));
+		}
     }
 
-	TakeGag(target: Character, location: string) {
+	TakeGag(target: Character, source: Character, handItemName: string, gagItemName: string, location: string) {
 		var gag = InventoryGet(target, location);
-		var existingHand = InventoryGet(Player, "ItemHandheld");
-		if (!gag || !!existingHand)
+		var existingHand = InventoryGet(source, "ItemHandheld");
+		if (!gag || !!existingHand || gag.Asset.Name != gagItemName)
 			return;
-		var validParams = ValidationCreateDiffParams(target, Player.MemberNumber!);
+		var validParams = ValidationCreateDiffParams(target, source.MemberNumber!);
 		if (ValidationCanRemoveItem(gag!, validParams, false)) {
 			InventoryRemove(target, location, true);
 			var craft = gag.Craft;
 			craft!.Lock = "";
-			InventoryWear(Player, "Ballgag", "ItemHandheld", gag.Color, undefined, Player.MemberNumber, craft, true);
+			InventoryWear(source, handItemName, "ItemHandheld", gag.Color, undefined, source.MemberNumber, craft, true);
 			setTimeout(() => ChatRoomCharacterItemUpdate(target, location));
+		}
+	}
+
+	TieUp(target: Character, source: Character, location: string) {
+		var handRope = InventoryGet(source, "ItemHandheld");
+		if (handRope?.Asset.Name.startsWith("RopeCoil")) {
+			var ropeTie = InventoryWear(target, "HempRope", location, handRope?.Color, undefined, source.MemberNumber, handRope?.Craft, true);
+			if (location == "ItemArms")
+				(<any>ropeTie!.Property!.Type!) = null;
+			setTimeout(() => ChatRoomCharacterItemUpdate(target, location));
+		}
+	}
+
+	getItemName(item: Item) {
+		return item.Craft?.Name ?? item.Asset.Description.toLocaleLowerCase();
+	}
+
+	TrySteal(target: Character, source: Character, item: Item) {
+		SendAction(`${CharacterNickname(source)} grabs at ${CharacterNickname(source)}'s ${this.getItemName(item)}, trying to steal it!`);
+		setTimeout(() => this.Steal_Roll(target, source, item), 5000);
+	}
+
+	get d20(): number {
+		return getRandomInt(20) + 1;
+	}
+
+	getDominance(C: Character) {
+		return C.Reputation.find(r => r.Type == "Dominant")?.Value ?? 0;
+	};
+
+	getSkill(C: Character, skillName: string): number {
+		let skill = C.Skill.find(r => r.Type == skillName);
+		return ((skill?.Level ?? 0) * (skill?.Ratio ?? 1));
+	}
+
+	getRollMod(C: Character, Opponent: Character, isThief: boolean = false): number {
+		// Dominant vs Submissive ==> -3 to +3 modifier
+		let dominanceMod = Math.floor(this.getDominance(C) / 33);
+		// +5 if we own our opponent
+		let ownershipMod = Opponent.IsOwnedByMemberNumber(C.MemberNumber!) ? 5 : 0;
+		// -4 if we're restrained
+		let restrainedMod = C.IsRestrained() ? -4 : 0;
+		// If edged, -0 to -4 based on arousal
+		let edgingMod = C.IsEdged() ? (Math.floor(C.ArousalSettings?.Progress ?? 0 / 25) * -1) : 0;
+		// -5 if we're incapacitated, automatic failure if we're also defending
+		let incapacitatedMod = getModule<BoopsModule>("BoopsModule")?.IsIncapacitated ? (isThief ? 5 : 100) * -1 : 0;
+		
+		let finalMod = dominanceMod + ownershipMod + restrainedMod + edgingMod + incapacitatedMod;
+
+		console.debug(`${CharacterNickname(C)} is ${isThief ? 'stealing from' : 'defending against'} ${CharacterNickname(Opponent)} [${finalMod}] --
+		dominanceMod: ${dominanceMod}
+		ownershipMod: ${ownershipMod}
+		restrainedMod: ${restrainedMod}
+		edgingMod: ${edgingMod}
+		incapacitatedMod: ${incapacitatedMod}
+		`);
+
+		return finalMod;
+	}
+
+	Steal_Roll(target: Character, source: Character, item: Item) {
+		let targetD20 = this.d20;
+		let targetMod = this.getRollMod(target, source, false);
+		let targetRoll = Math.max(0, targetD20 + targetMod);
+
+		let sourceD20 = this.d20;
+		let sourceMod = this.getRollMod(source, target, true);
+		let sourceRoll = Math.max(0, sourceD20 + sourceMod);
+
+		if (sourceRoll >= targetRoll) {
+			SendAction(`${CharacterNickname(source)} [${sourceD20}+${sourceMod}] manages to wrest ${CharacterNickname(target)}'s [${targetD20}+${targetMod}] ${this.getItemName(item)} out of their grasp!`);
+			InventoryRemove(target, "ItemHandheld", true);
+			InventoryWear(source, item.Asset.Name, "ItemHandheld", item.Color, item.Difficulty, source.MemberNumber, item.Craft, true);
+			setTimeout(() => ChatRoomCharacterItemUpdate(source, "ItemHandheld"));
+			setTimeout(() => ChatRoomCharacterItemUpdate(target, "ItemHandheld"));
+		}
+		else {
+			SendAction(`${CharacterNickname(source)} fails to steal ${CharacterNickname(target)}'s ${this.getItemName(item)} and is dazed from the attempt!`);
+			this.failedStealTime = CommonTime();
 		}
 	}
 }

--- a/src/Settings/Models/base.ts
+++ b/src/Settings/Models/base.ts
@@ -4,6 +4,7 @@ export interface BaseSettingsModel {
 
 export interface GlobalSettingsModel extends BaseSettingsModel {
     edgeBlur: boolean;
+    showCheckRolls: boolean;
 }
 
 export interface MiscSettingsModel extends BaseSettingsModel {

--- a/src/Settings/global.ts
+++ b/src/Settings/global.ts
@@ -70,7 +70,13 @@ export class GuiGlobal extends GuiSubscreen {
 				description: "Enabled breathplay using nose plugs and sufficient gags.",
 				setting: () => Player.LSCG.MiscModule.gagChokeEnabled ?? false,
 				setSetting: (val) => Player.LSCG.MiscModule.gagChokeEnabled = val
-			},
+			},<Setting>{
+				type: "checkbox",
+				label: "Show Check Rolls:",
+				description: "If enabled, will display the attacker/defender roll values for activity checks.",
+				setting: () => this.settings.showCheckRolls ?? true,
+				setSetting: (val) => this.settings.showCheckRolls = val
+			}
 		]
 	}
 

--- a/src/Settings/injector.ts
+++ b/src/Settings/injector.ts
@@ -6,7 +6,7 @@ import { GuiSubscreen, Setting } from "./settingBase";
 export class GuiInjector extends GuiSubscreen {
 
 	get name(): string {
-		return "Injector Enhancements";
+		return "Drug Enhancements";
 	}
 
 	get icon(): string {

--- a/src/Settings/settingUtils.ts
+++ b/src/Settings/settingUtils.ts
@@ -81,7 +81,8 @@ export class GUI extends BaseModule {
 	get defaultSettings(): GlobalSettingsModel {
 		return {
 			enabled: true,
-			edgeBlur: false
+			edgeBlur: false,
+			showCheckRolls: true
 		};
     }
 

--- a/src/Settings/setting_definitions.ts
+++ b/src/Settings/setting_definitions.ts
@@ -21,6 +21,7 @@ export enum ModuleCategory {
 	Lipstick = 4,
     Activities = 5,
 	Injector = 6,
+	ItemUse = 7,
 	RemoteUI = 98,
 	Misc = 99
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { ActivityModule } from "Modules/activities";
 import { InjectorModule } from 'Modules/injector';
 import { CoreModule } from 'Modules/core';
 import { RemoteUIModule } from 'Modules/remoteUI';
+import { ItemUseModule } from 'Modules/item-use';
 
 function initWait() {
 	console.debug("LSCG: Init wait");
@@ -97,6 +98,7 @@ function init_modules(): boolean {
 	registerModule(new LipstickModule());
 	registerModule(new ActivityModule());
 	registerModule(new InjectorModule());
+	registerModule(new ItemUseModule());
 	registerModule(new RemoteUIModule());
 
 	for (const m of modules()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import bcModSDKRef from "bondage-club-mod-sdk";
 import { getModule } from "modules";
 import { ActivityModule } from "Modules/activities";
+import { BoopsModule } from "Modules/boops";
 import { CoreModule } from "Modules/core";
 import { IPublicSettingsModel } from "Settings/Models/settings";
 import { ModuleCategory } from "Settings/setting_definitions";


### PR DESCRIPTION
Enhance item interactions with more custom activities:
- Use/Take ballgag
- Use/Take panty stuffing
- Give Item
- Steal Item
  - Makes contested dice rolls to determine success.
  - Roll is a d20 modified by dom(+)/sub(-) reputation, edging arousal, restrained status, LSCG incapacitation (sleep/hypno), and ownership (owner gets a +5 on their subs). Roll results are shown in emote and modifier breakdown is written to debug log.
  - If a steal fails, there is a 1-minute cooldown before another attempt can be made.

Updated drug options:
- Use crafted mugs and filled glasses as druggable items.
  - Use the 'sip' item action to force drink.
  - todo: make ungagged sips a contest?
- Drug types remain the same and use the same configuration as medical injector
- If injections are undesired, simply block the item in BC settings
- If you are ungagged, attempts to force you to drink will roll an activity check similar to the steal check above