### PR TITLE
Continuous drug delivery via Respirator

### DIFF
--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -1058,7 +1058,7 @@ export class InjectorModule extends BaseModule {
             let randomLevelIncrease = (getRandomInt(4) + 2) / 10; // .2 to .5
 
             // Event is 5% chance every 4s
-            if (getRandomInt(20) == 0) {
+            if (getRandomInt(14) == 0) {
                 randomLevelIncrease += 1;
                 if (types.indexOf("sedative") > -1 && this.settings.enableSedative) {
                     if (!this.asleep) SendAction(this.breathSedativeEventStr[getRandomInt(this.breathSedativeEventStr.length)]);

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -1057,7 +1057,7 @@ export class InjectorModule extends BaseModule {
             let types = this.GetDrugTypes(mask.Craft!);
             let randomLevelIncrease = (getRandomInt(4) + 2) / 10; // .2 to .5
 
-            // Event is 1 in n chance every 4s
+            // Event is 1 in n chance every 2s
             if (getRandomInt(14) == 0) {
                 randomLevelIncrease += 1;
                 if (types.indexOf("sedative") > -1 && this.settings.enableSedative) {
@@ -1072,7 +1072,7 @@ export class InjectorModule extends BaseModule {
                     SendAction(this.breathAphrodesiacEventStr[getRandomInt(this.breathAphrodesiacEventStr.length)]);
                     this.AddHorny(randomLevelIncrease, getRandomInt(3) != 0); // 2/3 chance to push user over the edge (if allowed...)
                 }
-            } else { // Do regular increase of drug level every 4s
+            } else { // Do regular increase of drug level every 2s
                 randomLevelIncrease = randomLevelIncrease / 4; // .025 to .125
                 if (types.indexOf("sedative") > -1 && this.settings.enableSedative) {
                     this.AddSedative(randomLevelIncrease, false);

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -950,6 +950,7 @@ export class InjectorModule extends BaseModule {
         if (this.IsWearingRespirator && this.IsRespiratorOn && !this._respiratorHasGas) {
             SendAction("%NAME%'s mask whirs and shudders as it reloads its own supply to continues emitting.");
             this.settings.continuousDeliveryActivatedAt = CommonTime();
+            settingsSave();
         } else if (this.IsWearingRespirator && !this.IsRespiratorOn) {
             SendAction("%NAME%'s mask hums menacingly as it holds its supply in reserve.");
         } else if (this.IsWearingRespirator && this.IsRespiratorOn && this._respiratorHasGas) {
@@ -963,6 +964,7 @@ export class InjectorModule extends BaseModule {
                 if (!this._respiratorHasGas) {
                     SendAction("%OPP_NAME% reloads %NAME%'s mask and turns it back on, pumping gas back into %POSSESSIVE% lungs.", sender);
                     this.settings.continuousDeliveryActivatedAt = CommonTime();
+                    settingsSave()
                 } else 
                     SendAction("%OPP_NAME% switches on %NAME%'s mask, filling %POSSESSIVE% lungs.", sender);
             } else {
@@ -980,6 +982,8 @@ export class InjectorModule extends BaseModule {
                 SendAction("%NAME%'s eyes widen as %POSSESSIVE% mask activates, slowly filling %POSSESSIVE% lungs with its drug.");
                 CharacterSetFacialExpression(Player, "Eyes", "Surprised", 4000);
             }
+            this.settings.continuousDeliveryActivatedAt = CommonTime();
+            settingsSave();
         } else if (this._wasWearingRespirator && !isWearing) {
             SendAction("%NAME% takes a deep breath of cool, clean air as %POSSESSIVE% mask is removed.");
         }
@@ -993,7 +997,7 @@ export class InjectorModule extends BaseModule {
 
     get RespiratorHasGas(): boolean {
         let hasGas = this._respiratorHasGas;
-        if (!hasGas && this.IsRespiratorOn) {
+        if (!hasGas && this.IsWearingRespirator && this.IsRespiratorOn) {
             SendAction("%NAME%'s mask hisses quietly as it runs out of its supply of gas.");
             let item = InventoryGet(Player, "ItemMouth3");
             if (!!item && !!item.Property && item.Property.Type) {

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -1057,7 +1057,7 @@ export class InjectorModule extends BaseModule {
             let types = this.GetDrugTypes(mask.Craft!);
             let randomLevelIncrease = (getRandomInt(4) + 2) / 10; // .2 to .5
 
-            // Event is 5% chance every 4s
+            // Event is 1 in n chance every 4s
             if (getRandomInt(14) == 0) {
                 randomLevelIncrease += 1;
                 if (types.indexOf("sedative") > -1 && this.settings.enableSedative) {

--- a/src/Settings/Models/injector.ts
+++ b/src/Settings/Models/injector.ts
@@ -23,6 +23,8 @@ export interface InjectorSettingsModel extends InjectorPublicSettingsModel {
     netgunIsChaotic: boolean;
     showDrugLevels: boolean;
     allowBoopRestore: boolean;
+    continuousDeliveryActivatedAt: number;
+    continuousDeliveryTimeout: number;
 }
 
 export interface InjectorPublicSettingsModel extends BaseSettingsModel {

--- a/src/base.ts
+++ b/src/base.ts
@@ -27,8 +27,7 @@ export abstract class BaseModule {
 		if (!Player.LSCG || !Player.LSCG.GlobalModule)
 			return false;
 		return Player.LSCG.GlobalModule.enabled && this.settings.enabled && 
-			(CurrentModule == "Online" || 
-			CurrentModule == "Character" || 
+			(ServerPlayerIsInChatRoom() || 
 			(CurrentModule == "Room" && CurrentScreen == "Crafting"));
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -267,6 +267,11 @@ export function addCustomEffect(C: Character | null, effect: EffectName): boolea
 		return updated;
 	}
 
+	if (Array.isArray(emoticon.Asset.AllowEffect))
+		emoticon.Asset.AllowEffect.push(effect);
+	else
+		emoticon.Asset.AllowEffect = [effect];
+
 	if (!emoticon.Property) {
 		emoticon.Property = { Effect: [effect] };
 		updated = true;
@@ -280,6 +285,7 @@ export function addCustomEffect(C: Character | null, effect: EffectName): boolea
 
 	if (updated && ServerPlayerIsInChatRoom() && C == Player) {
 		ChatRoomCharacterUpdate(Player);
+		CharacterRelease(Player, true);
 	}
 	return updated;
 }


### PR DESCRIPTION
Latex Respirator enhancements to allow continuous LSCG drug delivery

- Requires a crafted Latex Respirator with LSCG drug keyword(s)
- Respirator must have small or large tubes and they must have glow on to be "activated"
- Drug levels will slowly grow over time, with random events resulting in emotes, jumps in drug level, incapacitation minigames, and forced orgasms
- Once a respirator is "activated" (by wearing + turning the glow on) it will last an hour until it runs out of "gas"
  - Repirators can be reloaded by turning the 'glow' back on.
- Supports BCX cursing the respirator settings which can result in auto-reloading.