### PR TITLE
Dev refactors and improvements

### DIFF
--- a/lscgLoader-dev.user.js
+++ b/lscgLoader-dev.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG DEV
 // @namespace https://www.bondageprojects.com/
-// @version 0.3.19
+// @version 0.3.20
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*
@@ -15,7 +15,7 @@
 (function() {
     'use strict';
     var script = document.createElement("script");
-    script.type = "module";
+    script.langauge = "JavaScript";
     script.setAttribute("crossorigin", "anonymous");
     script.src = `https://littlesera.github.io/LSCG/dev/bundle.js?${Date.now()}`;
     document.head.appendChild(script);

--- a/lscgLoader.user.js
+++ b/lscgLoader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG
 // @namespace https://www.bondageprojects.com/
-// @version 0.3.19
+// @version 0.3.20
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*
@@ -15,7 +15,7 @@
 (function() {
     'use strict';
     var script = document.createElement("script");
-    script.type = "module";
+    script.langauge = "JavaScript";
     script.setAttribute("crossorigin", "anonymous");
     script.src = `https://littlesera.github.io/LSCG/bundle.js?${Date.now()}`;
     document.head.appendChild(script);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ls-club-games",
   "description": "Little Sera's Club Games",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "main": "dist/bundle.js",
   "scripts": {
     "build": "rollup -c",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -50,7 +50,6 @@ console.debug("LSCG: Parse start...");
   plugins: [
     progress({ clearLine: true }),
 		resolve({ browser: true }),
-		json(),
     typescript({ tsconfig: "./tsconfig.json", inlineSources: true }),
     commonjs()
   ]

--- a/src/Modules/States/ItemBundleBaseState.ts
+++ b/src/Modules/States/ItemBundleBaseState.ts
@@ -1,0 +1,63 @@
+import { BC_ItemsToItemBundles, SendAction, addCustomEffect, getRandomInt, isBind, isCloth, removeCustomEffect, settingsSave, stringIsCompressedItemBundleArray, waitFor } from "utils";
+import { BaseState, StateRestrictions } from "./BaseState";
+import { StateModule } from "Modules/states";
+import { OutfitConfig, OutfitOption, PolymorphOption, SpellDefinition } from "Settings/Models/magic";
+
+export abstract class ItemBundleBaseState extends BaseState {
+    storedOutfitKey: string = "stored-outfit";
+    get StoredOutfit(): ItemBundle[] | undefined {
+        let ext = this.config.extensions[this.storedOutfitKey];
+        if (!ext) return undefined;
+        try {
+            return JSON.parse(LZString.decompressFromBase64(ext));
+        }
+        catch {
+            return undefined;
+        }
+    }
+
+    SetStoredOutfit() {
+        this.config.extensions[this.storedOutfitKey] = LZString.compressToBase64(JSON.stringify(BC_ItemsToItemBundles(Player.Appearance)));
+        settingsSave();
+    }
+
+    ClearStoredOutfit() {
+        delete this.config.extensions[this.storedOutfitKey];
+        settingsSave();
+    }
+
+    abstract DoChange(asset: Asset | null, spell: SpellDefinition | null): boolean;
+
+    abstract StripCharacter(skipStore: boolean, spell: SpellDefinition | null, newList: ItemBundle[]): void;
+
+    abstract WearMany(items: ItemBundle[], spell: SpellDefinition | null, isRestore: boolean): void;
+
+    abstract Apply(spell: SpellDefinition, memberNumber?: number | undefined, duration?: number, emote?: boolean | undefined): BaseState;
+
+    Recover(emote?: boolean | undefined): BaseState {
+        super.Recover();
+        if (!!this.StoredOutfit) {
+            this.StripCharacter(true, null, []);
+            this.WearMany(this.StoredOutfit, null, true);
+            this.ClearStoredOutfit();
+        }
+        return this;
+    }
+
+    GetConfiguredItemBundles(code: string, filter: (item: ItemBundle) => boolean): ItemBundle[] {
+        let items: ItemBundle[] = [];
+        if (stringIsCompressedItemBundleArray(code)) {
+            items = JSON.parse(LZString.decompressFromBase64(code)) as ItemBundle[];
+        } 
+        // Code needs to actually be full info here, build it on the source side..
+        // else if (CommonIsNumeric(code) && !!Player.Wardrobe) {
+        //     let ix = parseInt(code);
+        //     if (ix >= 0 && ix < Player.Wardrobe.length)
+        //         items = Player.Wardrobe[ix];
+        // } else if (code.length <= 70 && typeof mbs !== "undefined") {
+        //     items = mbs.wheelOutfits.getByName(code)?.items ?? [];
+        // }
+        
+        return items.filter(item => filter(item));
+    }
+}

--- a/src/Modules/States/PolymorphedState.ts
+++ b/src/Modules/States/PolymorphedState.ts
@@ -1,25 +1,33 @@
 import { BC_ItemsToItemBundles, SendAction, addCustomEffect, getCharacter, getRandomInt, isBind, isBody, isCloth, isCosplay, isGenitals, isHair, isPronouns, isSkin, removeCustomEffect, settingsSave, waitFor } from "utils";
 import { BaseState, StateRestrictions } from "./BaseState";
 import { StateModule } from "Modules/states";
-import { PolymorphConfig, PolymorphOption } from "Settings/Models/magic";
+import { PolymorphConfig, PolymorphOption, SpellDefinition } from "Settings/Models/magic";
+import { ItemBundleBaseState } from "./ItemBundleBaseState";
 
-export class PolymorphedState extends BaseState {
+export class PolymorphedState extends ItemBundleBaseState {
     static CleanItemCode(code: string): string {
         let items = JSON.parse(LZString.decompressFromBase64(code)) as ItemBundle[];
-        if (!items)
+        if (!items || !Array.isArray(items))
             return code;
-        items = items.filter(item => {
-            let asset = AssetGet(Player.AssetFamily, item.Group, item.Name);
-            if (!asset)
-                return false;
-            return isCosplay(asset) || 
-                isBody(asset) ||
-                isHair(asset) ||
-                isSkin(asset) ||
-                isGenitals(asset);
-        });
+        items = items.filter(item => PolymorphedState.ItemIsAllowed(item));
         return LZString.compressToBase64(JSON.stringify(items));
     }
+
+    static ItemIsAllowed(item: ItemBundle): boolean {
+        let asset = AssetGet(Player.AssetFamily, item.Group, item.Name);
+        if (!asset)
+            return false;
+        return PolymorphedState.AssetIsAllowed(asset);
+    }
+
+    static AssetIsAllowed(asset: Asset): boolean {
+        return isCosplay(asset) || 
+            isBody(asset) ||
+            isHair(asset) ||
+            isSkin(asset) ||
+            isGenitals(asset);
+    }
+
 
     Type: LSCGState = "polymorphed";
 
@@ -36,29 +44,14 @@ export class PolymorphedState extends BaseState {
     }
 
     storedOutfitKey: string = "stored";
-    get StoredOutfit(): ItemBundle[] | undefined {
-        let ext = this.config.extensions[this.storedOutfitKey];
-        if (!ext) return undefined;
-        try {
-            return JSON.parse(LZString.decompressFromBase64(ext));
-        }
-        catch {
-            return undefined;
-        }
-    }
-
-    SetStoredOutfit() {
-        this.config.extensions[this.storedOutfitKey] = LZString.compressToBase64(JSON.stringify(BC_ItemsToItemBundles(Player.Appearance)));
-        settingsSave();
-    }
-
-    ClearStoredOutfit() {
-        delete this.config.extensions[this.storedOutfitKey];
-        settingsSave();
-    }
-
-    DoChange(asset: Asset | null, config: PolymorphConfig): boolean {
+    
+    DoChange(asset: Asset | null, spell: SpellDefinition | null): boolean {
         if (!asset)
+            return false;
+        if (!spell)
+            return PolymorphedState.AssetIsAllowed(asset);
+        let config = spell.Polymorph;
+        if (!config)
             return false;
         
         let allow = config.IncludeCosplay && isCosplay(asset);
@@ -80,7 +73,7 @@ export class PolymorphedState extends BaseState {
         "Mouth"
     ]
 
-    StripCharacter(skipStore: boolean, config: PolymorphConfig, newList: ItemBundle[] = []) {
+    StripCharacter(skipStore: boolean, spell: SpellDefinition, newList: ItemBundle[] = []) {
         if (!skipStore && !this.StoredOutfit)
             this.SetStoredOutfit();
 
@@ -88,9 +81,9 @@ export class PolymorphedState extends BaseState {
         let appearance = Player.Appearance;
         for (let i = appearance.length - 1; i >= 0; i--) {
             const asset = appearance[i].Asset;
-            if (this.DoChange(asset, config)) {
+            if (this.DoChange(asset, spell)) {
                 let newItem = newList.find(x => x.Group == asset.Group.Name);
-                if (!config.IncludeAllBody && config.IncludeSkin && 
+                if (!spell.Polymorph?.IncludeAllBody && spell.Polymorph?.IncludeSkin && 
                     !!newItem && 
                     this.skinColorChangeOnly.indexOf(asset.Group.Name) > -1) {
                     // Special handling for simple color change.
@@ -103,40 +96,33 @@ export class PolymorphedState extends BaseState {
         }
     }
 
-    Apply(outfit: PolymorphConfig, memberNumber?: number | undefined, duration?: number,  emote?: boolean | undefined): BaseState {
+    Apply(spell: SpellDefinition, memberNumber?: number | undefined, duration?: number,  emote?: boolean | undefined): BaseState {
         try{
-            let outfitList = JSON.parse(LZString.decompressFromBase64(outfit.Code)) as ItemBundle[];
+            let outfit = spell.Polymorph;
+            if (!outfit)
+                return this;
+            let outfitList = this.GetConfiguredItemBundles(outfit.Code, item => PolymorphedState.ItemIsAllowed(item));
             if (!!outfitList && typeof outfitList == "object") {
-                this.StripCharacter(false, outfit, outfitList);
-                this.WearMany(outfitList, outfit);
+                this.StripCharacter(false, spell, outfitList);
+                this.WearMany(outfitList, spell);
                 super.Activate(memberNumber, duration, emote);
             }
         }
         catch {
-            console.warn("error parsing outfitcode in PolymorphedState: " + outfit.Code);
+            console.warn("error parsing outfitcode in PolymorphedState: " + spell.Polymorph?.Code);
         }
         return this;
     }
 
-    Recover(emote?: boolean | undefined): BaseState {
-        super.Recover();
-        if (!!this.StoredOutfit) {
-            this.StripCharacter(true, <PolymorphConfig>{IncludeCosplay: true, IncludeAllBody: true});
-            this.WearMany(this.StoredOutfit, <PolymorphConfig>{IncludeCosplay: true, IncludeAllBody: true}, true);
-            this.ClearStoredOutfit();
-        }
-        return this;
-    }
-
-    WearMany(items: ItemBundle[], config: PolymorphConfig, isRestore: boolean = false) {
+    WearMany(items: ItemBundle[], spell: SpellDefinition, isRestore: boolean = false) {
         items.forEach(item => {
             let asset = AssetGet(Player.AssetFamily, item.Group, item.Name);
-            if (!!asset && this.DoChange(asset, config)) {
+            if (!!asset && this.DoChange(asset, spell)) {
                 //let groupBlocked = InventoryGroupIsBlockedForCharacter(Player, asset.Group.Name);
                 let isBlocked = InventoryBlockedOrLimited(Player, {Asset: asset})
                 let isRoomDisallowed = !InventoryChatRoomAllow(asset?.Category ?? []);
 
-                let isSkinColorChangeOnly = !config.IncludeAllBody && config.IncludeSkin && this.skinColorChangeOnly.indexOf(asset.Group.Name) > -1;
+                let isSkinColorChangeOnly = !spell.Polymorph?.IncludeAllBody && spell.Polymorph?.IncludeSkin && this.skinColorChangeOnly.indexOf(asset.Group.Name) > -1;
                 if (isRestore || !(isBlocked || isRoomDisallowed || isSkinColorChangeOnly)) {
                     let newItem = InventoryWear(Player, item.Name, item.Group, item.Color, item.Difficulty, -1, item.Craft, false);
                     if (!!newItem && !!item.Property)

--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -704,7 +704,7 @@ export class ActivityModule extends BaseModule {
             },
             Targets: [
                 {
-                    Name: "ItemHands",
+                    Name: "ItemMouth",
                     SelfAllowed: true,
                     SelfOnly: true,
                     TargetLabel: "Eat",

--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -179,7 +179,7 @@ export class CoreModule extends BaseModule {
                 Player.LSCG = <SettingsModel>{};
                 this.registerDefaultSettings();
             }
-            Player.LSCG.Version = LSCG_VERSION;
+            previousVersion = Player.LSCG.Version = LSCG_VERSION;
             settingsSave();
         }
         this.CheckForMigrations(previousVersion);

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -159,7 +159,7 @@ export class ItemUseModule extends BaseModule {
 			let res;
 			if (["GagGiveItem", "GagTakeItem","GagToNecklace", "NecklaceToGag"].indexOf(needsItem) > -1) {
 				res = this.ManualGenerateItemActivitiesForNecklaceActivity(allowed, acting, acted, needsItem, activity);
-			} else if (needsItem == "FellatioItem" || needsItem == "EdibleItem") {
+			} else if (needsItem == "FellatioItem") {
 				let tmpActivity = Object.assign({}, activity);
 				tmpActivity.Reverse = true;
 				if (activity.Name == "LSCG_Suck" || activity.Name == "LSCG_Throat")

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -378,6 +378,8 @@ export class MagicModule extends BaseModule {
                 // If this specific activity is clicked, we run it
                 if (!MouseIn(x, y, width, height)) return false;
                 let blocked = spell.Effects.some(effect => blockedSpellTypes.indexOf(effect) > -1);
+                spell = JSON.parse(JSON.stringify(spell));
+                this.UnpackSpellCodes(spell);
                 
                 if (!blocked) {
                     this.CastSpellInitial(spell, CurrentCharacter);
@@ -396,6 +398,8 @@ export class MagicModule extends BaseModule {
         if (!spell || this.settings.trueWildMagic)
             spell = this.RandomSpell
         let paired: Character | undefined = undefined;
+        spell = JSON.parse(JSON.stringify(spell));
+        this.UnpackSpellCodes(spell);
         if (this.SpellNeedsPair(spell))
             paired = this.PairedCharacterOptions(C)[getRandomInt(this.PairedCharacterOptions(C).length)];
         this.CastSpellActual(spell, C, paired);
@@ -465,14 +469,6 @@ export class MagicModule extends BaseModule {
             }
             else {
                 SendAction(this.getCastingActionString(spell, InventoryGet(Player, "ItemHandheld"), spellTarget, pairedTarget), spellTarget);
-            }
-
-            // Unpack specified outfit codes for sending.
-            if (!!spell.Outfit && !!spell.Outfit.Code) {
-                spell.Outfit.Code = LZString.compressToBase64(JSON.stringify(GetConfiguredItemBundlesFromSavedCode(spell.Outfit.Code, item => RedressedState.ItemIsAllowed(item))));
-            } 
-            if (!!spell.Polymorph && spell.Polymorph.Code) {
-                spell.Polymorph.Code = LZString.compressToBase64(JSON.stringify(GetConfiguredItemBundlesFromSavedCode(spell.Polymorph.Code, item => PolymorphedState.ItemIsAllowed(item))));
             }
 
             if (spellTarget.IsPlayer()) {
@@ -829,6 +825,8 @@ export class MagicModule extends BaseModule {
         let spells = Player.LSCG.MagicModule.knownSpells.filter(s => s.AllowPotion && !s.Effects.some(e => pairedSpellEffects.indexOf(e) > -1));
         let spell = spells?.filter(x => !!x)?.find(x => !!x && !!x.Name && isPhraseInString(itemStr, x.Name));
         if (!!spell)
+            spell = JSON.parse(JSON.stringify(spell));
+            this.UnpackSpellCodes(spell);
             sendLSCGCommandBeep(senderNum, "get-spell-response", [{
                 name: "spell",
                 value: spell
@@ -856,6 +854,18 @@ export class MagicModule extends BaseModule {
             setTimeout(() => {
                 this.HandleQuaffWithSpell(sender, itemName, spell);
             }, 1000);
+        }
+    }
+
+    UnpackSpellCodes(spell: SpellDefinition | undefined) {
+        if (!spell)
+            return;
+        // Unpack specified outfit codes for sending.
+        if (!!spell.Outfit && !!spell.Outfit.Code) {
+            spell.Outfit.Code = LZString.compressToBase64(JSON.stringify(GetConfiguredItemBundlesFromSavedCode(spell.Outfit.Code, item => RedressedState.ItemIsAllowed(item))));
+        } 
+        if (!!spell.Polymorph && spell.Polymorph.Code) {
+            spell.Polymorph.Code = LZString.compressToBase64(JSON.stringify(GetConfiguredItemBundlesFromSavedCode(spell.Polymorph.Code, item => PolymorphedState.ItemIsAllowed(item))));
         }
     }
 }

--- a/src/Settings/Models/magic.ts
+++ b/src/Settings/Models/magic.ts
@@ -35,21 +35,20 @@ export enum PolymorphOption {
     both = "Body and Cosplay",
 }
 
-export interface OutfitConfig {
+export interface ItemBundleConfig {
     Code: string;
+}
+
+export interface OutfitConfig extends ItemBundleConfig {
     Option: OutfitOption;
 }
 
-export interface PolymorphConfig {
-    Code: string;
+export interface PolymorphConfig extends ItemBundleConfig {
     IncludeCosplay: boolean;
     IncludeSkin: boolean;
     IncludeHair: boolean;
     IncludeGenitals: boolean;
-    IncludeAllBody: boolean;
-    
-    // Deprecated
-    Option: PolymorphOption;
+    IncludeAllBody: boolean;    
 }
 
 export interface SpellDefinition {

--- a/src/Settings/magic.ts
+++ b/src/Settings/magic.ts
@@ -1,6 +1,9 @@
 import { GuiSubscreen, Setting } from "./settingBase";
 import { KNOWN_SPELLS_LIMIT, LSCGSpellEffect, MagicSettingsModel, OutfitConfig, OutfitOption, PolymorphConfig, PolymorphOption, SpellDefinition } from "./Models/magic";
 import { PairedBaseState } from "Modules/States/PairedBaseState";
+import { stringIsCompressedItemBundleArray } from "utils";
+import { PolymorphedState } from "Modules/States/PolymorphedState";
+import { RedressedState } from "Modules/States/RedressedState";
 
 export const pairedSpellEffects = [
 	LSCGSpellEffect.orgasm_siphon,
@@ -641,7 +644,8 @@ export class GuiMagic extends GuiSubscreen {
 	ConfirmOutfit() {
 		this._ConfigureOutfit = false;
 		if (!this.Spell.Outfit) this.Spell.Outfit = {Code: "", Option: OutfitOption.both};
-		this.Spell.Outfit.Code = ElementValue(this.outfitFieldId);
+		let outfitCode = this.ParseCode(ElementValue(this.outfitFieldId), code => RedressedState.CleanItemCode(code));
+		this.Spell.Outfit.Code = outfitCode;
 		this.ElementSetValue(this.outfitFieldId, "");
 	}
 	OutfitConfigDropChanged(evt: any) {
@@ -664,18 +668,9 @@ export class GuiMagic extends GuiSubscreen {
 	ConfirmPolymorph() {
 		this._ConfigurePolymorph = false;
 		if (!this.Spell.Polymorph) this.Spell.Polymorph = <PolymorphConfig>{};
-		this.Spell.Polymorph.Code = ElementValue(this.outfitFieldId);
+		let polymorphCode = this.ParseCode(ElementValue(this.outfitFieldId), code => PolymorphedState.CleanItemCode(code));
+		this.Spell.Polymorph.Code = polymorphCode;
 		this.ElementSetValue(this.outfitFieldId, "");
-	}
-	PolymorphConfigDropChanged(evt: any) {
-		if (!!this.Spell) {
-			if (!this.Spell.Polymorph)
-				this.Spell.Polymorph = <PolymorphConfig>{
-					Code: "",
-					Option: PolymorphOption.both
-				}
-			this.Spell.Polymorph.Option = evt.target.value as PolymorphOption;
-		}
 	}
 
 	static SpellEffectDescription(effect: LSCGSpellEffect): string {
@@ -716,5 +711,14 @@ export class GuiMagic extends GuiSubscreen {
 			default:
 				return ""			;
 		}
+	}
+
+	ParseCode(code: string, trimFunc: (str: string) => string): string {
+		if (stringIsCompressedItemBundleArray(code))
+			return trimFunc(code);
+		else if (CommonIsNumeric(code) || code.length <= 70)
+			return code;
+		else
+			return "";
 	}
 }

--- a/src/club_existing/declarations.d.ts
+++ b/src/club_existing/declarations.d.ts
@@ -2,4 +2,5 @@ declare const LSCG_VERSION: string;
 
 interface Window {
 	LSCG_Loaded?: boolean;
+	LSCG_Version?: string;
 }

--- a/src/club_existing/mbs.d.ts
+++ b/src/club_existing/mbs.d.ts
@@ -1,0 +1,83 @@
+/**
+ * MBS: Maid's Bondage Scripts
+ *
+ * Copyright (C) 2023 Bananarama92
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+
+/**
+ * Uncomment the `ItemBundle` declaration below if, for one reason or another, you do not
+ * have access to the builtin BC type annotations.
+ * @note Use of the builtin `ItemBundle` BC type is *strongly* recommended
+ */
+// type ItemBundle = Record<string, any>;
+
+/** An interface for exposing MBS wheel of fortune data */
+interface WheelBundle {
+    /** The (user-specified) name of the item set. */
+    name: string;
+    /** The index of the wheel of fortune item set */
+    index: number;
+    /** A list of the minified items associated with the item set */
+    items: ItemBundle[];
+}
+
+/** Maid's Bondage Scripts: Various additions and utility scripts for BC. */
+declare namespace mbs {
+    /**
+     * The (semantic) MBS version.
+     * Guaranteed to match the `/^([0-9]+)\.([0-9]+)\.([0-9]+)(\S+)?$/` regex.
+     */
+    const MBS_VERSION: `${number}.${number}.${number}${string}`;
+    /**
+     * The version of the MBS API.
+     *
+     * * Changes or removals are accompanied by a `major` increment (and resetting `minor` back to 0)
+     * * Additions are only accompanied by a `minor` increment
+     */
+    const API_VERSION: {
+        /** The major API versions; increments are reserved for changes and removals */
+        readonly major: number,
+        /** The major API versions; increments are reserved for additions */
+        readonly minor: number,
+    };
+    /**
+     * Run the MBS test suit.
+     * @returns Whether the test suite succeeded or not
+     */
+    function runTests(): boolean;
+    /** Public MBS API for retrieving wheel outfit data. */
+    namespace wheelOutfits {
+        /**
+         * Get a record mapping all (user-specified) outfit names to the actual outfit data.
+         * @returns All MBS outfit data
+         */
+        function getAll(): Record<string, WheelBundle>;
+        /**
+         * Get a single wheel outfit by its name.
+         * @param name The name of the wheel outfit
+         * @returns The wheel outfit or `undefined` if it cannot be found
+         */
+        function getByName(name: string): undefined | WheelBundle;
+        /**
+         * Get a single wheel outfit by its index.
+         * @param index The wheel outfit or `undefined` if it cannot be found
+         * @returns The MBS outfit data or `undefined`
+         */
+        function getByIndex(index: number): undefined | WheelBundle;
+        /** Return a list of all the players wheel outfit names. */
+        function getNames(): string[];
+        /** Return a list of all the players wheel outfit indices. */
+        function getIndices(): number[];
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+"use strict";
 import { hookFunction, ICONS, isObject, settingsSave } from './utils';
 import { ConfiguredActivities, CraftableItemSpellNames, DrugKeywords, HypnoTriggers, modules, NetgunKeywords, registerModule } from 'modules';
 import { SettingsModel } from 'Settings/Models/settings';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
-"use strict";
-import { hookFunction, ICONS, isObject, settingsSave } from './utils';
+import { GetDataSizeReport, hookFunction, ICONS, isObject, settingsSave } from './utils';
 import { ConfiguredActivities, CraftableItemSpellNames, DrugKeywords, HypnoTriggers, modules, NetgunKeywords, registerModule } from 'modules';
 import { SettingsModel } from 'Settings/Models/settings';
 import { HypnoModule } from './Modules/hypno';
@@ -17,7 +16,14 @@ import { ItemUseModule } from 'Modules/item-use';
 import { StateModule } from 'Modules/states';
 import { MagicModule } from 'Modules/magic';
 
-export { DrugKeywords, NetgunKeywords, CraftableItemSpellNames, HypnoTriggers, ConfiguredActivities };
+export { 
+	DrugKeywords, 
+	NetgunKeywords, 
+	CraftableItemSpellNames, 
+	HypnoTriggers, 
+	ConfiguredActivities, 
+	GetDataSizeReport 
+};
 
 function initWait() {
 	console.debug("LSCG: Init wait");
@@ -37,13 +43,13 @@ function initWait() {
 	}
 }
 
-export function loginInit(C: any) {
+function loginInit(C: any) {
 	if (window.LSCG_Loaded)
 		return;
 	init();
 }
 
-export function initSettingsScreen() {
+function initSettingsScreen() {
 	PreferenceSubscreenList.push("LSCGMainMenu");
 	hookFunction("TextGet", 2, (args: string[], next: (arg0: any) => any) => {
 		if (args[0] == "HomepageLSCGMainMenu") return "LSCG Settings";
@@ -55,7 +61,7 @@ export function initSettingsScreen() {
 	});
 }
 
-export function init() {
+function init() {
 	if (window.LSCG_Loaded)
 		return;
 	
@@ -153,7 +159,7 @@ function init_modules(): boolean {
 	return true;
 }
 
-export function unload(): true {
+function unload(): true {
 	unload_modules();
 
 	delete window.LSCG_Loaded;


### PR DESCRIPTION
* Allow using MBS and Wardrobe sets for outfit/polymorph spell effects.
  * Use index number for Wardrobe and set name for MBS sets
  * This allows for data reuse and should help reduce packet size for LSCG users
* Trim base64 outfit/polymorph codes on save.
  * When you save an encoded ItemBundle[] list, it will be filtered for items that actually apply to the spell effect, throwing away unnecessary data.
* Switch tampermonkey loader to use 'script' type instead of 'module' to better export a public API.
  * TAMPERMONKEY LOADER NEEDS REINSTALL FOR THIS TO WORK
* Move bread eat activity to mouth to match sip + quaff