### PR TITLE
Changes to `drawTooltip`

### DIFF
--- a/src/Settings/settingUtils.ts
+++ b/src/Settings/settingUtils.ts
@@ -107,15 +107,8 @@ export function drawTooltip(x: number, y: number, width: number, text: string, a
 	const canvas = MainCanvas;
 	const bak = canvas.textAlign;
 	canvas.textAlign = align;
-	canvas.beginPath();
-	canvas.rect(x, y, width, 65);
-	canvas.fillStyle = "#FFFF88";
-	canvas.fillRect(x, y, width, 65);
-	canvas.fill();
-	canvas.lineWidth = 2;
-	canvas.strokeStyle = "black";
-	canvas.stroke();
-	canvas.closePath();
+	DrawRect(x, y, width, 65, "#FFFF88");
+	DrawEmptyRect(x, y, width, 65, "black", 2);
 	DrawTextFit(
 		text,
 		align === "left" ? x + 3 : x + width / 2,


### PR DESCRIPTION
Changed `drawTooltip` to use BC functions, instead of canvas specific ones.