### PR TITLE
Updates and Fixes from Dev

### DIFF
--- a/lscgLoader-dev.user.js
+++ b/lscgLoader-dev.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG DEV
 // @namespace https://www.bondageprojects.com/
-// @version 0.3.31
+// @version 0.3.32
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*

--- a/lscgLoader.user.js
+++ b/lscgLoader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG
 // @namespace https://www.bondageprojects.com/
-// @version 0.3.31
+// @version 0.3.32
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ls-club-games",
   "description": "Little Sera's Club Games",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "main": "dist/bundle.js",
   "scripts": {
     "build": "rollup -c",

--- a/src/Modules/States/FrozenState.ts
+++ b/src/Modules/States/FrozenState.ts
@@ -27,7 +27,11 @@ export class FrozenState extends BaseState {
             if (this.Active)
                 return false;
             return next(args);
-        })
+        });
+
+        hookFunction("Player.IsEnclose", 1, (args, next) => {
+            return this.Active || next(args);
+        });
     }
 
     RoomSync(): void {}

--- a/src/Modules/States/PolymorphedState.ts
+++ b/src/Modules/States/PolymorphedState.ts
@@ -104,7 +104,7 @@ export class PolymorphedState extends ItemBundleBaseState {
             let outfitList = this.GetConfiguredItemBundles(outfit.Code, item => PolymorphedState.ItemIsAllowed(item));
             if (!!outfitList && typeof outfitList == "object") {
                 this.StripCharacter(false, spell, outfitList);
-                this.WearMany(outfitList, spell);
+                this.WearMany(outfitList, spell, false, memberNumber);
                 super.Activate(memberNumber, duration, emote);
             }
         }
@@ -114,12 +114,14 @@ export class PolymorphedState extends ItemBundleBaseState {
         return this;
     }
 
-    WearMany(items: ItemBundle[], spell: SpellDefinition, isRestore: boolean = false) {
+    WearMany(items: ItemBundle[], spell: SpellDefinition, isRestore: boolean = false, memberNumber: number | undefined = undefined) {
+        if (!memberNumber)
+            memberNumber = Player.MemberNumber ?? 0;
+        let sender = !!memberNumber ? getCharacter(memberNumber) : null;
         items.forEach(item => {
             let asset = AssetGet(Player.AssetFamily, item.Group, item.Name);
             if (!!asset && this.DoChange(asset, spell)) {
-                //let groupBlocked = InventoryGroupIsBlockedForCharacter(Player, asset.Group.Name);
-                let isBlocked = InventoryBlockedOrLimited(Player, {Asset: asset})
+                let isBlocked = this.InventoryBlockedOrLimited(Player, {Asset: asset});
                 let isRoomDisallowed = !InventoryChatRoomAllow(asset?.Category ?? []);
 
                 let isSkinColorChangeOnly = (!spell || (!spell.Polymorph?.IncludeAllBody && spell.Polymorph?.IncludeSkin)) && this.skinColorChangeOnly.indexOf(asset.Group.Name) > -1;

--- a/src/Modules/States/RedressedState.ts
+++ b/src/Modules/States/RedressedState.ts
@@ -94,7 +94,7 @@ export class RedressedState extends ItemBundleBaseState {
             let asset = AssetGet(Player.AssetFamily, item.Group, item.Name);
             if (!!asset && this.DoChange(asset, spell)) {
                 //let groupBlocked = InventoryGroupIsBlockedForCharacter(Player, asset.Group.Name);
-                let isBlocked = InventoryBlockedOrLimited(Player, {Asset: asset})
+                let isBlocked = InventoryBlockedOrLimited(Player, {Asset: asset});
                 let isRoomDisallowed = !InventoryChatRoomAllow(asset?.Category ?? []);
                 if (isRestore || !(isBlocked || isRoomDisallowed)) {
                     let newItem = InventoryWear(Player, item.Name, item.Group, item.Color, item.Difficulty, -1, item.Craft, false);

--- a/src/Modules/States/XRayVisionState.ts
+++ b/src/Modules/States/XRayVisionState.ts
@@ -37,7 +37,7 @@ export class XRayVisionState extends BaseState {
     Activate(memberNumber?: number | undefined, duration?: number | undefined, emote?: boolean | undefined): BaseState | undefined {
         let ret = super.Activate(memberNumber, duration, emote);
         ChatRoomCharacter.forEach(C => {
-            CharacterAppearanceBuildCanvas(C);
+            CharacterLoadCanvas(C);
         });
         return ret;
     }
@@ -45,7 +45,7 @@ export class XRayVisionState extends BaseState {
     Recover(emote?: boolean | undefined): BaseState | undefined {
         let ret = super.Recover(emote);
         ChatRoomCharacter.forEach(C => {
-            CharacterAppearanceBuildCanvas(C);
+            CharacterLoadCanvas(C);
         });
         return ret;
     }

--- a/src/Modules/States/XRayVisionState.ts
+++ b/src/Modules/States/XRayVisionState.ts
@@ -32,22 +32,6 @@ export class XRayVisionState extends BaseState {
             }
             return ret;
         }, ModuleCategory.States);
-
-        // hookFunction("CommonDrawAppearanceBuild", 1, (args, next) => {
-        //     let C = args[0] as OtherCharacter;
-        //     if (this.Active && this.CanViewXRay(C)) {
-        //         let callbacks = args[1];
-        //         C.AppearanceLayers?.forEach((Layer) => {
-        //             const A = Layer.Asset;
-        //             if (isCloth(A)) {
-        //                 A.DynamicBeforeDraw = true;
-        //             }
-        //         });
-        //         let ret = next(args);
-        //         return ret;
-        //     } else
-        //         return next(args);
-        // }, ModuleCategory.States);
     }
 
     Activate(memberNumber?: number | undefined, duration?: number | undefined, emote?: boolean | undefined): BaseState | undefined {

--- a/src/Modules/States/XRayVisionState.ts
+++ b/src/Modules/States/XRayVisionState.ts
@@ -1,0 +1,76 @@
+import { SendAction, addCustomEffect, getRandomInt, hookFunction, isBind, isCloth, removeCustomEffect } from "utils";
+import { BaseState, StateRestrictions } from "./BaseState";
+import { StateModule } from "Modules/states";
+import { ModuleCategory } from "Settings/setting_definitions";
+
+export class XRayVisionState extends BaseState {
+    Type: LSCGState = "x-ray-vision";
+
+    Icon(C: OtherCharacter): string {
+        return "Icons/Explore.png";
+    }
+    Label(C: OtherCharacter): string {
+        return "X-Ray Vision";
+    }
+
+    constructor(state: StateModule) {
+        super(state);
+    }
+
+    Init(): void {
+        hookFunction("CommonCallFunctionByNameWarn", 1, (args, next) => {
+            let funcName = args[0];
+            let params = args[1]
+            let C = params['C'] as OtherCharacter;
+            let CA = params['CA'];
+            let ret = next(args) ?? {};
+            let regex = /Assets(.+)BeforeDraw/i;
+            if (regex.test(funcName) && this.Active && this.CanViewXRay(C) && !!CA && isCloth(CA)) {
+                let curOpacity = ret.Opacity ?? CA.Asset?.Opacity ?? 1;
+                ret.Opacity = curOpacity * .5;
+                ret.AlphaMasks = [];
+            }
+            return ret;
+        }, ModuleCategory.States);
+
+        // hookFunction("CommonDrawAppearanceBuild", 1, (args, next) => {
+        //     let C = args[0] as OtherCharacter;
+        //     if (this.Active && this.CanViewXRay(C)) {
+        //         let callbacks = args[1];
+        //         C.AppearanceLayers?.forEach((Layer) => {
+        //             const A = Layer.Asset;
+        //             if (isCloth(A)) {
+        //                 A.DynamicBeforeDraw = true;
+        //             }
+        //         });
+        //         let ret = next(args);
+        //         return ret;
+        //     } else
+        //         return next(args);
+        // }, ModuleCategory.States);
+    }
+
+    Activate(memberNumber?: number | undefined, duration?: number | undefined, emote?: boolean | undefined): BaseState | undefined {
+        let ret = super.Activate(memberNumber, duration, emote);
+        ChatRoomCharacter.forEach(C => {
+            CharacterAppearanceBuildCanvas(C);
+        });
+        return ret;
+    }
+
+    Recover(emote?: boolean | undefined): BaseState | undefined {
+        let ret = super.Recover(emote);
+        ChatRoomCharacter.forEach(C => {
+            CharacterAppearanceBuildCanvas(C);
+        });
+        return ret;
+    }
+
+    CanViewXRay(C: PlayerCharacter | OtherCharacter) {
+        return (C?.LSCG?.MagicModule?.enabled && !C?.LSCG?.MagicModule?.blockXRay) ?? false;
+    }
+
+    RoomSync(): void {}
+
+    SpeechBlock(): void {}
+}

--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -186,12 +186,16 @@ export class ActivityModule extends BaseModule {
         })
 
         hookFunction("DrawImageResize", 1, (args, next) => {
-            var path = <string>args[0];
-            if (!!path && path.indexOf("LSCG_") > -1) {
-                var activityName = path.substring(path.indexOf("LSCG_"));
-                activityName = activityName.substring(0, activityName.indexOf(".png"))
-                if (this.CustomImages.has(activityName))
-                    args[0] = this.CustomImages.get(activityName);
+            try {
+                var path = <string>args[0];
+                if (!!path && path.indexOf("LSCG_") > -1) {
+                    var activityName = path.substring(path.indexOf("LSCG_"));
+                    activityName = activityName.substring(0, activityName.indexOf(".png"))
+                    if (this.CustomImages.has(activityName))
+                        args[0] = this.CustomImages.get(activityName);
+                }
+            } catch (error) {
+                console.debug(error);
             }
             return next(args);
         }, ModuleCategory.Activities)

--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -232,6 +232,25 @@ export class CoreModule extends BaseModule {
             });
             return next(args);
         }, ModuleCategory.Core);
+
+        hookFunction("InventoryGetItemProperty", 1, (args, next) => {
+            let item = args[0];
+            let prop = args[1];
+            if (prop == "HideItemExclude" && (item?.Property?.LSCGOpacity ?? 1) < 1) {
+                let result = (item.Property.HideItemExclude ?? []) as string[];
+                let hideGroups = item.Asset.Hide;
+                if (!hideGroups)
+                    return result;
+                AssetMap.forEach((a) => {
+                    if (hideGroups.indexOf(a.Group.Name) > -1) 
+                        result.push(`${a.Group.Name}${a.Name}`);
+                });
+                result = result.filter((v, ix, arr) => arr.indexOf(v) == ix);
+                return result;
+            } else {
+                return next(args);
+            }
+        }, ModuleCategory.Core);
     }
 
     opacitySlider: HTMLInputElement | null = null;

--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -255,9 +255,13 @@ export class CoreModule extends BaseModule {
 
         hookFunction("CharacterAppearanceSortLayers", 1, (args, next) => {
             let C = args[0] as OtherCharacter;
+            if (!C.MemberNumber)
+                return next(args);
+
             let xray = getModule<StateModule>("StateModule")?.XRayState;
+            let xrayActive = xray?.Active && xray?.CanViewXRay(C);
             C.DrawAppearance?.forEach(item => {
-                if ((item.Property?.LSCGOpacity ?? 1) < 1 || (xray?.Active && xray?.CanViewXRay(C))) {
+                if ((item.Property?.LSCGOpacity ?? 1) < 1 || xrayActive) {
                     item.Asset = Object.assign({}, item.Asset);
                     item?.Asset?.Layer?.forEach(layer => {
                         layer.Alpha = [];
@@ -276,7 +280,6 @@ export class CoreModule extends BaseModule {
                 }
 
                 if (item.Asset.Name == "Penis") {
-                    let xrayActive = xray?.Active && xray?.CanViewXRay(C);
                     let transpPants = (InventoryGet(C, "ClothLower")?.Property?.LSCGOpacity ?? 1) > 1;
                     let transpUnderwear = (InventoryGet(C, "Panties")?.Property?.LSCGOpacity ?? 1) > 1;
                     if ((xrayActive || transpPants || transpUnderwear) && (!item.Property || !item.Property?.OverridePriority)) {
@@ -398,6 +401,7 @@ export class CoreModule extends BaseModule {
         if (!Sender)
             return;
         Sender.LSCG = Object.assign(Sender.LSCG ?? {}, msg.settings ?? {});
+        CharacterLoadCanvas(Sender);
         if (msg.reply) {
             this.SendPublicPacket(false, msg.type);
         }

--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -3,7 +3,7 @@ import { getModule, modules } from "modules";
 import { BaseSettingsModel, GlobalSettingsModel } from "Settings/Models/base";
 import { IPublicSettingsModel, PublicSettingsModel, SettingsModel } from "Settings/Models/settings";
 import { ModuleCategory } from "Settings/setting_definitions";
-import { removeAllHooksByModule, hookFunction, getCharacter, drawSvg, SVG_ICONS, sendLSCGMessage, settingsSave, LSCG_CHANGES, LSCG_SendLocal, mouseTooltip } from "../utils";
+import { removeAllHooksByModule, hookFunction, getCharacter, drawSvg, SVG_ICONS, sendLSCGMessage, settingsSave, LSCG_CHANGES, LSCG_SendLocal, mouseTooltip, isCloth } from "../utils";
 import { ActivityModule, GrabType } from "./activities";
 import { HypnoModule } from "./hypno";
 import { CollarModule } from "./collar";
@@ -164,8 +164,125 @@ export class CoreModule extends BaseModule {
                 settingsSave();
                 DialogInventoryBuild(C, true, false);
             }
-        })
+        });
+
+        hookFunction("ItemColorLoad", 1, (args, next) => {
+            next(args);
+            let C = args[0] as Character;
+            let Item = args[1] as Item;
+            if (C.IsPlayer() && isCloth(Item)) {
+                this.OpacityCharacter = C;
+                this.OpacityItem = Item;
+                ElementPosition(this.opacityEleId, 250, 200, 300, 20);
+                ElementPosition(this.opacityLabelId, 250, 150, 300, 20);
+                ElementValue(this.opacityEleId, "" + (this.OpacityItem?.Property?.LSCGOpacity ?? 1));
+            }
+        });
+
+        hookFunction("ItemColorFireExit", 1, (args, next) => {
+            next(args);
+            this.OpacityCharacter = null;
+            this.OpacityItem = null;
+            ElementPosition(this.opacityEleId, -999, -999, 1, 1);
+            ElementPosition(this.opacityLabelId, -999, -999, 1, 1);
+        });
+
+        hookFunction("CommonCallFunctionByNameWarn", 2, (args, next) => {
+            let funcName = args[0];
+            let params = args[1]
+            let C = params['C'] as OtherCharacter;
+            let CA = params['CA'];
+            let ret = next(args) ?? {};
+            let regex = /Assets(.+)BeforeDraw/i;
+            if (regex.test(funcName) && !!CA && isCloth(CA)) {
+                ret.Opacity = Math.min((ret.Opacity ?? 1), (CA.Property?.LSCGOpacity ?? CA.Asset?.Opacity ?? 1));
+            }
+            return ret;
+        }, ModuleCategory.Core);
+
+        hookFunction("CommonDrawAppearanceBuild", 1, (args, next) => {
+            let C = args[0] as OtherCharacter;
+            let callbacks = args[1];
+            C.AppearanceLayers?.forEach((Layer) => {
+                const A = Layer.Asset;
+                if (isCloth(A)) {
+                    A.DynamicBeforeDraw = true;
+                }
+            });
+            let ret = next(args);
+            return ret;
+        }, ModuleCategory.Core);
+
+        hookFunction("CharacterAppearanceSortLayers", 1, (args, next) => {
+            let C = args[0] as Character;
+            C.DrawAppearance?.forEach(item => {
+                if ((item.Property?.LSCGOpacity ?? 1) < 1) {
+                    item?.Asset?.Layer?.forEach(layer => {
+                        layer.Alpha = [];
+                    });
+                } else {
+                    let defaultAsset = AssetMap.get(`${item?.Asset?.Group?.Name}/${item.Asset.Name}`);
+                    if (!!defaultAsset) {
+                        item?.Asset?.Layer?.forEach((layer, ix, arr) => {
+                            if (defaultAsset!.Alpha)
+                                layer.Alpha = defaultAsset!.Alpha;
+                        });
+                    }
+                }
+            });
+            return next(args);
+        }, ModuleCategory.Core);
     }
+
+    opacitySlider: HTMLInputElement | null = null;
+    opacityLabel: HTMLLabelElement | null = null;
+    opacityEleId: string = "LSCG_OpacitySlider";
+    opacityLabelId: string = "LSCG_OpacitySlider_Label";
+    OpacityItem: Item | null = null;
+    OpacityCharacter: Character | null = null;
+    run() {
+        this.opacitySlider = ElementCreateRangeInput(
+            this.opacityEleId,
+            1,
+            0,
+            1,
+            0.01
+        );
+        this.opacityLabel = this.CreateOpacityLabel();
+        ElementPosition(this.opacityEleId, -999, -999, 1, 1);
+        ElementPosition(this.opacityLabelId, -999, -999, 1, 1);
+        this.opacitySlider.addEventListener("input", (e) => this.OpacityChange());
+    }
+
+    CreateOpacityLabel() {
+        if (document.getElementById(this.opacityLabelId) == null) {
+            const label = document.createElement("label");
+            label.setAttribute("id", this.opacityLabelId);
+            label.setAttribute("for", this.opacityEleId);
+            label.style.color = "#FFF";
+            label.innerText = "Opacity";
+            document.body.appendChild(label);
+            return label;
+        } else
+            return document.getElementById(this.opacityLabelId) as HTMLLabelElement;
+    }
+
+    OpacityChange() {
+        if (!this.OpacityItem)
+            return;
+
+        let value = parseFloat(ElementValue(this.opacityEleId));
+        let C = Player;
+        if (!this.OpacityItem.Property)
+            this.OpacityItem.Property = {};
+        this.OpacityItem.Property.LSCGOpacity = value;
+        this.UpdatePreview();
+    }
+
+    UpdatePreview = CommonLimitFunction(() => {
+        if (!!this.OpacityCharacter)
+            CharacterLoadCanvas(this.OpacityCharacter);
+    });
 
     _drawShareToggleButton(X: number, Y: number, Width: number, Height: number) {
         DrawButton(X, Y, Width, Height, "", this.settings.seeSharedCrafts ? "White" : "Red", "", "Toggle Shared Crafts", false);

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1009,7 +1009,7 @@ export class ItemUseModule extends BaseModule {
 		var handRope = InventoryGet(source, "ItemHandheld");
 		if (handRope?.Asset.Name.startsWith("RopeCoil")) {
 			var ropeTie = InventoryWear(target, rope.ItemName, rope.Location, handRope?.Color, undefined, source.MemberNumber, handRope?.Craft, true);
-			if (!!rope.Type)
+			if (!!rope.Type && !!ropeTie)
 				(<any>ropeTie!.Property!.Type!) = rope.Type;
 			setTimeout(() => ChatRoomCharacterUpdate(target));
 		}

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -59,7 +59,8 @@ export class MagicModule extends BaseModule {
             allowOutfitToChangeNeckItems: false,
             allowChangeGenitals: true,
             allowChangePronouns: false,
-            requireWhitelist: false
+            requireWhitelist: false,
+            blockXRay: false
         };
     }
 
@@ -528,7 +529,8 @@ export class MagicModule extends BaseModule {
     SpellIsBeneficial(spell: SpellDefinition) {
         let beneficialEffects: LSCGSpellEffect[] = [
             LSCGSpellEffect.dispell,
-            LSCGSpellEffect.bless
+            LSCGSpellEffect.bless,
+            LSCGSpellEffect.xRay
         ];
         return  spell.Effects.every(e => beneficialEffects.indexOf(e) > -1);
     }
@@ -665,6 +667,10 @@ export class MagicModule extends BaseModule {
                             state = this.stateModule.OrgasmSiphonedState.DoPair(paired, sender, duration);
                             this.NotifyPair(sender, paired, LSCGSpellEffect.orgasm_siphon, this.stateModule.OrgasmSiphonedState.Type);
                         }
+                        break;
+                    case LSCGSpellEffect.xRay:
+                        SendAction(`%NAME% blinks with a grin.`);
+                        state = this.stateModule.XRayState.Activate(sender?.MemberNumber, duration);
                         break;
                 }
             }, 2000 * ix);

--- a/src/Modules/states.ts
+++ b/src/Modules/states.ts
@@ -19,6 +19,7 @@ import { ItemUseModule } from "./item-use";
 import { ResizedState } from "./States/ResizedState";
 import { BuffedState } from "./States/BuffedState";
 import { PolymorphedState } from "./States/PolymorphedState";
+import { XRayVisionState } from "./States/XRayVisionState";
 
 interface StateIcon {
     Label: string;
@@ -75,6 +76,7 @@ export class StateModule extends BaseModule {
     BuffedState: BuffedState;
     ArousalPairedState: ArousalPairedState;
     OrgasmSiphonedState: OrgasmSiphonedState;
+    XRayState: XRayVisionState;
 
     GetRestriction(state: BaseState, restriction: LSCGImmersiveOption): boolean {
         return state.Active &&
@@ -104,6 +106,7 @@ export class StateModule extends BaseModule {
         this.BuffedState = new BuffedState(this);
         this.ArousalPairedState = new ArousalPairedState(this);
         this.OrgasmSiphonedState = new OrgasmSiphonedState(this);
+        this.XRayState = new XRayVisionState(this);
 
         this.States = [
             this.SleepState, 
@@ -118,7 +121,8 @@ export class StateModule extends BaseModule {
             this.ResizedState,
             this.ArousalPairedState,
             this.OrgasmSiphonedState,
-            this.BuffedState
+            this.BuffedState,
+            this.XRayState
         ];
         
         // States module in general is always enabled. Toggling is done on each specific state.

--- a/src/Settings/Models/magic.ts
+++ b/src/Settings/Models/magic.ts
@@ -19,7 +19,8 @@ export enum LSCGSpellEffect {
     orgasm_siphon = "Siphoning", 
     outfit = "Outfit",
     polymorph = "Polymorph",
-    dispell = "Dispell"
+    dispell = "Dispell",
+    xRay = "X-Ray Vision"
 }
 
 export enum OutfitOption {
@@ -87,4 +88,7 @@ export interface MagicPublicSettingsModel extends BaseSettingsModel{
     limitedDuration: boolean;
     maxDuration: number;
     requireWhitelist: boolean;
+
+    // XRay Block
+    blockXRay: boolean;
 }

--- a/src/Settings/Models/settings.ts
+++ b/src/Settings/Models/settings.ts
@@ -129,6 +129,7 @@ export class PublicSettingsModel implements IPublicSettingsModel {
         maxDuration: 0,
         allowOutfitToChangeNeckItems: false,
         allowChangeGenitals: true,
-        requireWhitelist: false
+        requireWhitelist: false,
+        blockXRay: false
     }
 }

--- a/src/Settings/Remote/magic.ts
+++ b/src/Settings/Remote/magic.ts
@@ -160,6 +160,12 @@ export class RemoteMagic extends RemoteGuiSubscreen {
 				description: "If checked, polymorph spell effects can modify your genitals.",
 				setting: () => this.settings.allowChangeGenitals ?? true,
 				setSetting: (val) => this.settings.allowChangeGenitals = val
+			}, <Setting>{
+				type: "checkbox",
+				label: "Prevent XRay Vision",
+				description: "Enhance your clothing with xray-vision-blockers.",
+				setting: () => this.settings.blockXRay ?? false,
+				setSetting: (val) => this.settings.blockXRay = val
 			}
 		]]
 	}

--- a/src/Settings/Remote/magic.ts
+++ b/src/Settings/Remote/magic.ts
@@ -162,7 +162,7 @@ export class RemoteMagic extends RemoteGuiSubscreen {
 				setSetting: (val) => this.settings.allowChangeGenitals = val
 			}, <Setting>{
 				type: "checkbox",
-				label: "Prevent XRay Vision",
+				label: "Prevent X-Ray Vision",
 				description: "Enhance your clothing with xray-vision-blockers.",
 				setting: () => this.settings.blockXRay ?? false,
 				setSetting: (val) => this.settings.blockXRay = val

--- a/src/Settings/magic.ts
+++ b/src/Settings/magic.ts
@@ -71,7 +71,7 @@ export class GuiMagic extends GuiSubscreen {
 					setSetting: (val) => this.settings.trueWildMagic = val
 				}, <Setting>{
 					type: "checkbox",
-					label: "Prevent XRay Vision",
+					label: "Prevent X-Ray Vision",
 					description: "Enhance your clothing with xray-vision-blockers.",
 					setting: () => this.settings.blockXRay ?? false,
 					setSetting: (val) => this.settings.blockXRay = val

--- a/src/Settings/magic.ts
+++ b/src/Settings/magic.ts
@@ -70,6 +70,12 @@ export class GuiMagic extends GuiSubscreen {
 					setting: () => this.settings.trueWildMagic ?? false,
 					setSetting: (val) => this.settings.trueWildMagic = val
 				}, <Setting>{
+					type: "checkbox",
+					label: "Prevent XRay Vision",
+					description: "Enhance your clothing with xray-vision-blockers.",
+					setting: () => this.settings.blockXRay ?? false,
+					setSetting: (val) => this.settings.blockXRay = val
+				}, <Setting>{
 					type: "label",
 					label: "Blocked Effects:",
 					description: "Toggle which spell effects you want to block on yourself."
@@ -369,11 +375,11 @@ export class GuiMagic extends GuiSubscreen {
 					this.settings.blockedSpellEffects = [];
 				let val = this.settings.blockedSpellEffects.indexOf(this.Effect) > -1;
 				let blockedStr = val ? "Blocked" : "Allowed";
-				DrawBackNextButton(780, this.getYPos(4)-32, 600, 64, this.Effect, "White", "", () => blockedStr, () => blockedStr);
-				DrawCheckbox(780 + 600 + 64, this.getYPos(4) - 32, 64, 64, "", val);
+				DrawBackNextButton(780, this.getYPos(5)-32, 600, 64, this.Effect, "White", "", () => blockedStr, () => blockedStr);
+				DrawCheckbox(780 + 600 + 64, this.getYPos(5) - 32, 64, 64, "", val);
 
 				MainCanvas.textAlign = "left";
-				DrawTextFit(GuiMagic.SpellEffectDescription(this.Effect), 780, this.getYPos(5), 1000, "Black");
+				DrawTextFit(GuiMagic.SpellEffectDescription(this.Effect), 780, this.getYPos(6), 1000, "Black");
 				MainCanvas.textAlign = "center";
 			} else if (PreferencePageCurrent == 2) {
 				if (this.settings.knownSpells.length > 0) {
@@ -484,9 +490,9 @@ export class GuiMagic extends GuiSubscreen {
 			}
 		} else if (!this.settings.locked) {
 			if (PreferencePageCurrent == 1) {
-				if (MouseIn(780, this.getYPos(4)-32, 600, 64)) {
+				if (MouseIn(780, this.getYPos(5)-32, 600, 64)) {
 					this.EffectIndex = this.GetNewIndexFromNextPrevClick(1080, this.EffectIndex, this.ActualEffects.length);
-				} else if (MouseIn(780 + 600 + 64, this.getYPos(4) - 32, 64, 64)) {
+				} else if (MouseIn(780 + 600 + 64, this.getYPos(5) - 32, 64, 64)) {
 					if (this.settings.blockedSpellEffects.indexOf(this.Effect) > -1)
 						this.settings.blockedSpellEffects = this.settings.blockedSpellEffects.filter(ef => ef != this.Effect);
 					else this.settings.blockedSpellEffects.push(this.Effect);
@@ -706,7 +712,9 @@ export class GuiMagic extends GuiSubscreen {
 			case LSCGSpellEffect.bane:
 				return "Applies a -5 debuff to all the target's skills for 15 minutes";
 			case LSCGSpellEffect.polymorph:
-				return "Polymorph the target's body and/or cosplay items"
+				return "Polymorph the target's body and/or cosplay items";
+			case LSCGSpellEffect.xRay:
+				return "Grants the target X-Ray vision";
 			case LSCGSpellEffect.none:
 			default:
 				return ""			;

--- a/src/club_existing/bc/Typedef.d.ts
+++ b/src/club_existing/bc/Typedef.d.ts
@@ -2626,6 +2626,8 @@ interface ItemPropertiesCustom {
 	/** Lucky Wheel: the angle the wheel should spin to */
 	TargetAngle?: number;
 
+	// Custom LSCG property to override opacity
+	LSCGOpacity?: number;
 }
 
 interface ItemProperties extends ItemPropertiesBase, AssetDefinitionProperties, ItemPropertiesCustom { }

--- a/src/club_existing/type-overrides.d.ts
+++ b/src/club_existing/type-overrides.d.ts
@@ -29,7 +29,7 @@ type LSCGMessageModelType = "init" | "sync" | "command";
 
 type LSCGCommandName = "debug" | "grab" | "release" | "remote" | "escape" | "collar-tighten" | "collar-loosen" | "collar-stats" | "photo" | "spell" | "spell-teach" | "pair" | "unpair" | "pairing-update" | "get-spell" | "get-spell-response";
 
-type LSCGState = "none" | "hypnotized" | "asleep" | "horny" | "choking" | "held" | "blind" | "deaf" | "frozen" | "gagged" | "redressed" | "arousal-paired" | "orgasm-siphoned" | "leashed" | "resized" | "buffed" | "polymorphed";
+type LSCGState = "none" | "hypnotized" | "asleep" | "horny" | "choking" | "held" | "blind" | "deaf" | "frozen" | "gagged" | "redressed" | "arousal-paired" | "orgasm-siphoned" | "leashed" | "resized" | "buffed" | "polymorphed" | "x-ray-vision";
 
 type LSCGImmersiveOption = "true" | "false" | "whenImmersive";
 


### PR DESCRIPTION
* Null check fix for rope tie activity
* Fix for error during DrawImageResize on activity thumbnails
* Fix "Petrified" spell effect not preventing movement in new map rooms
* Allow opacity on any clothing item
  * Note: Only visible when using LSCG. Clipping issues very possible.
* Add "X-ray vision" spell effect
  * Will render all clothes at 50% opacity if the wearer has magic enabled and has not set "Prevent X-Ray" true in their magic settings.