### PR TITLE
BUG: Fix `HoldingDruggedDrink` checking for items in the wrong group

### DIFF
--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -1001,7 +1001,7 @@ export class InjectorModule extends BaseModule {
     }
 
     HoldingDruggedDrink(C: Character): boolean {
-        var item = InventoryGet(C, "Handheld");
+        var item = InventoryGet(C, "ItemHandheld");
         if (!item || (item.Asset.Name != "GlassFilled" && item.Asset.Name != "Mug") || !item.Craft)
             return false;
         var drugTypes = this.GetDrugTypes(item.Craft!);


### PR DESCRIPTION
Fixes an invalid group name: `Handheld` -> `ItemHandheld`.