### PR TITLE
Fix HornyState not ending on timer

### DIFF
--- a/src/Modules/States/HornyState.ts
+++ b/src/Modules/States/HornyState.ts
@@ -35,6 +35,7 @@ export class HornyState extends BaseState {
         if (this.Active && !!Player.ArousalSettings && getRandomInt(1) == 0) {
             Player.ArousalSettings.Progress++;
         }
+        super.Tick(now);
     }
 
     RoomSync(): void {}


### PR DESCRIPTION
In current version, horny state caused by time-limited magic does not end when it's duration is finished and just continue indefinitely. It seems the problem is missing `super.Tick()` call in `HornyState`'s overriden `Tick()` method, which I've fixed in this PR.

