### PR TITLE
Updates from Dev

### DIFF
--- a/lscgLoader-dev.user.js
+++ b/lscgLoader-dev.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG DEV
 // @namespace https://www.bondageprojects.com/
-// @version 0.4.15
+// @version 0.4.16
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*

--- a/lscgLoader.user.js
+++ b/lscgLoader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG
 // @namespace https://www.bondageprojects.com/
-// @version 0.4.15
+// @version 0.4.16
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ls-club-games",
   "description": "Little Sera's Club Games",
-  "version": "0.4.15", 
+  "version": "0.4.16", 
   "main": "dist/bundle.js",
   "scripts": {
     "build": "rollup -c",

--- a/src/Modules/hypno.ts
+++ b/src/Modules/hypno.ts
@@ -1042,11 +1042,24 @@ export class HypnoModule extends BaseModule {
             return;
         }
         let groups = clothing.groups;
+        
+
+        if (clothing.random) {
+            let allGroups = AssetGroup
+                            .filter(g => g.Family === Player.AssetFamily && g.Category === "Appearance" && g.AllowCustomize && isCloth(g, false))
+                            .map(g => g.Name)
+                            .filter(g => Player.Appearance.some(a => a.Asset.Group.Name == g));
+            groups = allGroups.length > 0 ? [allGroups[getRandomInt(allGroups.length)]] : [];
+            if (groups.length <= 0) {
+                LSCG_SendLocal(`You feel disappointed that you have no more clothes to remove.`);
+            }
+        }
+        else if (clothing.all) {
+            groups = AssetGroup.filter(g => g.Family === Player.AssetFamily && g.Category === "Appearance" && g.AllowCustomize && isCloth(g, false)).map(g => g.Name);
+        }
+        
         SendAction(`%NAME% starts to remove clothing from %POSSESSIVE% body.`);
 
-        if (clothing.all) 
-            groups = AssetGroup.filter(g => g.Family === Player.AssetFamily && g.Category === "Appearance" && g.AllowCustomize && isCloth(g, false)).map(g => g.Name);
-        
         groups.forEach(grp => {
             InventoryRemove(Player, grp, false);
         });

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -636,8 +636,10 @@ export class InjectorModule extends BaseModule {
         // else
         this.sedativeLevel = newLevel;
 
-        if (!this.asleep && minigame)
+        if (!this.asleep && minigame) {
+            DialogLeave();
             MiniGameStart(this.sleepyGame.name, ((this.sedativeLevel / this.drugLevelMultiplier) * 8), "LSCG_InjectEnd_Sedative");
+        }
 
         CurrentModule = "Online";
     }

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -1210,8 +1210,8 @@ export class InjectorModule extends BaseModule {
 
     breathAntidoteEventStr: string[] = [
         "%NAME% sighs with relief as %PRONOUN% takes a deep gulp of healing mist.",
-        "%NAME% feels a tingle across %POSSESSIVE% skin as %POSSESSIVE% mask heals them.",
-        "%NAME% lets out a quiet moan as %POSSESSIVE% mask releases a healing mist into her lungs."
+        "%NAME% feels a tingle across %POSSESSIVE% skin as %POSSESSIVE% mask heals %INTENSIVE%.",
+        "%NAME% lets out a quiet moan as %POSSESSIVE% mask releases a healing mist into %INTENSIVE% lungs."
     ];
 
     BreathInDrugEvent() {

--- a/src/Settings/Remote/suggestions.ts
+++ b/src/Settings/Remote/suggestions.ts
@@ -20,6 +20,7 @@ export interface ActivitySelection {
 
 export interface ClothingSelection {
 	all: boolean;
+	random: boolean;
 	groups: string[];
 }
 
@@ -351,7 +352,7 @@ export class RemoteSuggestions extends RemoteHypno {
 			let coords = {x: 600, y: 100, w: 800, h: 800};
 			let currentValue = this._selectionValue as ClothingSelection;
 			if (!currentValue) {
-				this._selectionValue = <ClothingSelection>{all: false, groups: []};
+				this._selectionValue = <ClothingSelection>{all: false, random: false, groups: []};
 				currentValue = this._selectionValue as ClothingSelection;
 			}
 
@@ -361,7 +362,13 @@ export class RemoteSuggestions extends RemoteHypno {
 			DrawImageResize("Icons/Next.png", coords.x + coords.w - 86, coords.y + 22, 60, 60);
 			
 			this.DrawCheckboxAbsolute("All Slots", "", currentValue.all, {
-				x: coords.x + coords.w/2 - 100,
+				x: coords.x + coords.w/2 - 250,
+				y: coords.y + 20 + 32,
+				w: 100
+			});
+
+			this.DrawCheckboxAbsolute("Random", "", currentValue.random, {
+				x: coords.x + coords.w/2 - 50,
 				y: coords.y + 20 + 32,
 				w: 100
 			});
@@ -370,18 +377,18 @@ export class RemoteSuggestions extends RemoteHypno {
 
 			let columns = this._getClothingSlotColumns();
 			columns[0].forEach((slot, ix, arr) => {
-				this.DrawCheckboxAbsolute(slot, "", currentValue.all || currentValue.groups.indexOf(slot) > -1, {
+				this.DrawCheckboxAbsolute(slot, "", !currentValue.random && (currentValue.all || currentValue.groups.indexOf(slot) > -1), {
 					x: coords.x + 20,
 					y: coords.y + 200 + (80*ix),
 					w: 200
-				}, currentValue.all);
+				}, currentValue.all || currentValue.random);
 			});
 			columns[1].forEach((slot, ix, arr) => {
-				this.DrawCheckboxAbsolute(slot, "", currentValue.all || currentValue.groups.indexOf(slot) > -1, {
+				this.DrawCheckboxAbsolute(slot, "", !currentValue.random && (currentValue.all || currentValue.groups.indexOf(slot) > -1), {
 					x: coords.x + 400,
 					y: coords.y + 200 + (80*ix),
 					w: 200
-				}, currentValue.all);
+				}, currentValue.all || currentValue.random);
 			});
 		} else if (this._SelectConfigureInstruction?.type == LSCGHypnoInstruction.forget) {
 			let currentValue = this._selectionValue as ForgetSelection;
@@ -513,9 +520,14 @@ export class RemoteSuggestions extends RemoteHypno {
 				// Next
 				this._clothingPageIndex++;
 				if (this._clothingPageIndex > maxPageIx) this._clothingPageIndex = 0;
-			} else if (MouseIn(coords.x + coords.w/2 - 100, coords.y + 20, 100 + 64, 64)) {
+			} else if (MouseIn(coords.x + coords.w/2 - 150, coords.y + 20, 100 + 64, 64)) {
 				// All
 				currentValue.all = !currentValue.all;
+				if (currentValue.all) currentValue.random = false;
+			} else if (MouseIn(coords.x + coords.w/2 - 50, coords.y + 20, 100 + 64, 64)) {
+				// Random
+				currentValue.random = !currentValue.random;
+				if (currentValue.random) currentValue.all = false;
 			}
 
 			if (!currentValue.all) {


### PR DESCRIPTION
* Fix some hardcoded pronouns in action strings
* Add the ability to make any item have "tamper-proof" reactions. (note: does not immediately make something inescapable, just adds punishments to struggling, using struggle activity, or getting struggle help from someone)
  * Item must contain "tamperproof", "tamper-proof" or "tamper proof" in its crafted name or description
  * Tamper protection type can then be added in crafted name/description. eg: "electric", "subduing", "self tightening"
* Add checkbox to configure a strip suggestion instruction to pick a random piece of clothing each time (fixes #560)