### PR TITLE
MAINT: Adapt to the R109 crafted item description changes

### DIFF
--- a/src/Modules/collar.ts
+++ b/src/Modules/collar.ts
@@ -462,7 +462,7 @@ export class CollarModule extends BaseModule {
                 return true;
             else {
                 var name = item.Craft.Name;
-                var description = item.Craft.Description;
+                var description = typeof CraftingDescription === "undefined" ? item.Craft.Description : CraftingDescription.Decode(item.Craft.Description); // R109
                 var totalString = name + " | " + description;
         
                 return !isPhraseInString(totalString, "breathable");

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -547,7 +547,7 @@ export class InjectorModule extends BaseModule {
 
     GetDrugTypes(item: CraftingItem): DrugType[] {
         var name = item.Name;
-        var description = item.Description;
+        var description = typeof CraftingDescription === "undefined" ? item.Description : CraftingDescription.Decode(item.Description); // R109
         var totalString = name + " | " + description;
 
         var types: DrugType[] = [];

--- a/src/club_existing/type-overrides.d.ts
+++ b/src/club_existing/type-overrides.d.ts
@@ -49,3 +49,6 @@ interface LSCGMessageModel {
         args: {name: string, value: any}[]
     }
 }
+
+// >= R109
+declare var CraftingDescription: undefined | { Decode: (description: string) => string  };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -743,7 +743,7 @@ export function GetItemNameAndDescriptionConcat(item: Item | null): string | und
 		return;
 	
 	var name = item.Craft.Name;
-	var description = item.Craft.Description;
+	var description = typeof CraftingDescription === "undefined" ? item.Craft.Description : CraftingDescription.Decode(item.Craft.Description); // R109
 	return name + " | " + description;
 }
 


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5210](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5210)

Previously available in MBS, R109 adds the (optional) ability to use longer crafted item descriptions at the cost of limiting the available character set to extended ASCII. As a consequence, the affected descriptions now have to be decoded in order to retrieve the actual legible item description that can be used by the likes of LSCG's injector and collar modules.