### PR TITLE
New Magic features: Magic barrier and Voice casting

### DIFF
--- a/src/Modules/States/BarrierState.ts
+++ b/src/Modules/States/BarrierState.ts
@@ -1,0 +1,35 @@
+import { ICONS, SendAction } from "utils";
+import { BaseState } from "./BaseState";
+import { StateModule } from "Modules/states";
+
+export class BarrierState extends BaseState {
+    Type: LSCGState = "protected";
+    static BUFF_DURATION: number = 900000; // 15min
+
+    Icon(C: OtherCharacter): string {
+        return ICONS.UP;
+    }
+    Label(C: OtherCharacter): string {
+        return "Protected";
+    }
+
+    constructor(state: StateModule) {
+        super(state);
+    }
+
+    Barrier(MemberNumber?: number, emote?: boolean, duration?: number): BaseState {
+        if (emote) SendAction("A magic barrier appear around %NAME%.");
+        this.Activate(MemberNumber, duration ?? BarrierState.BUFF_DURATION, emote);
+        return this;
+    }
+
+    Activate(memberNumber?: number | undefined, duration?: number, emote?: boolean | undefined): BaseState | undefined {
+        return super.Activate(memberNumber, duration, emote);
+    }
+
+    Init(): void {}
+
+    RoomSync(): void {}
+
+    SpeechBlock(): void {}
+}

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1042,7 +1042,7 @@ export class ItemUseModule extends BaseModule {
 		// +/- 5 for buff state
 		let buffMod = (!buffState || !buffState.active) ? 0 : ((buffState.extensions["negative"] ?? false) ? -5 : 5);
 		// +5 magic barrier
-		let protectedMod = (protectedState) ? +5 : 0;
+		let protectedMod = (!protectedState || !protectedState.active) ? 0 : +5;
 
 		let finalMod = dominanceMod + ownershipMod + restrainedMod + edgingMod + incapacitatedMod + breathMod + buffMod + protectedMod;
 	

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1025,6 +1025,7 @@ export class ItemUseModule extends BaseModule {
 	
 	getRollMod(C: Character, Opponent?: Character, isAggressor: boolean = false): number {
 		let buffState = (C as OtherCharacter)?.LSCG?.StateModule?.states?.find(s => s.type == "buffed");
+		let protectedState = (C as OtherCharacter)?.LSCG?.StateModule?.states?.find(s => s.type == "protected");
 
 		// Dominant vs Submissive ==> -3 to +3 modifier
 		let dominanceMod = Math.floor(getDominance(C) / 33);
@@ -1040,8 +1041,10 @@ export class ItemUseModule extends BaseModule {
 		let breathMod = (C.IsPlayer() ? getModule<CollarModule>("CollarModule").totalChokeLevel : (C as OtherCharacter).LSCG?.CollarModule.chokeLevel ?? 0) * -2;
 		// +/- 5 for buff state
 		let buffMod = (!buffState || !buffState.active) ? 0 : ((buffState.extensions["negative"] ?? false) ? -5 : 5);
+		// +5 magic barrier
+		let protectedMod = (protectedState) ? +5 : 0;
 
-		let finalMod = dominanceMod + ownershipMod + restrainedMod + edgingMod + incapacitatedMod + breathMod + buffMod;
+		let finalMod = dominanceMod + ownershipMod + restrainedMod + edgingMod + incapacitatedMod + breathMod + buffMod + protectedMod;
 	
 		console.debug(`${CharacterNickname(C)} is ${isAggressor ? 'rolling against' : 'defending against'} ${!Opponent ? "nobody" : CharacterNickname(Opponent)} [${finalMod}] --
 		dominanceMod: ${dominanceMod}

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -721,6 +721,23 @@ export class MagicModule extends BaseModule {
                     case LSCGSpellEffect.barrier:
                         state = this.stateModule.BarrierState.Barrier(sender?.MemberNumber, true, duration);
                         break;
+                    case LSCGSpellEffect.disarm:
+                        var handItem = InventoryGet(Player, "ItemHandheld");
+                        if (!handItem) {
+                            SendAction(`The spell has no effect as %NAME%'s hand are already empty.`);
+                            break;
+                        }
+                        var validParams = ValidationCreateDiffParams(Player, sender?.MemberNumber!);
+                        if (ValidationCanRemoveItem(handItem, validParams, false)) {
+                            InventoryRemove(Player, "ItemHandheld", true);
+                            CharacterRefresh(Player, true);
+                            ChatRoomCharacterUpdate(Player);
+                            SendAction(`%NAME% squirms as the item in %POSSESSIVE% hand get ejected away by magic.`);
+                        }
+                        else {
+                            SendAction(`The spell was not strong enough to disarm %NAME%.`);
+                        }
+                        break;
                     case LSCGSpellEffect.outfit:
                         if (!!spell.Outfit?.Code) {
                             this.stateModule.GaggedState.Active ? 

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -589,7 +589,7 @@ export class MagicModule extends BaseModule {
         setTimeout(() => {
             if (msg.command?.name == "spell") {
                 let paired = getCharacter((msg.command?.args.find(arg => arg.name == "paired")?.value as number));
-                let magicBarrierActive = Player?.LSCG?.StateModule?.states?.find(s => s.type == "protected"); // is Magic barrier active on Player
+                let magicBarrier = Player?.LSCG?.StateModule?.states?.find(s => s.type == "protected");
                 let spell = msg.command?.args?.find(arg => arg.name == "spell")?.value as SpellDefinition;
                 if (!spell || !sender)
                     return;
@@ -597,7 +597,7 @@ export class MagicModule extends BaseModule {
                 if (!this.SpellIsBeneficial(spell) && this.DefendAgainst(sender.MemberNumber ?? -1)) {
                     if (check.AttackerRoll.Total < check.DefenderRoll.Total) {
                         SendAction(`${CharacterNickname(Player)} ${check.DefenderRoll.TotalStr}successfully saves against ${CharacterNickname(sender)}'s ${check.AttackerRoll.TotalStr}${spell.Name}.`);
-                        if (magicBarrierActive) {
+                        if (magicBarrier?.active) {
                             // if saved with a protected barrier, the spell will bounce back to sender
                             SendAction(`The magical barrier around ${CharacterNickname(Player)} make the spell bounce back to ${CharacterNickname(sender)}!`);
                             sendLSCGCommand(sender, "spell", [
@@ -615,7 +615,7 @@ export class MagicModule extends BaseModule {
                         return;
                     }
                 }
-                if (magicBarrierActive) {
+                if (magicBarrier?.active) {
                     this.stateModule.BarrierState.Recover(false);
                     SendAction(`The magical barrier around ${CharacterNickname(Player)} shatters, pierced by ${CharacterNickname(sender)}'s spell!`);
                 }

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -854,11 +854,11 @@ export class MagicModule extends BaseModule {
 
     CheckForSpellVoiceCasting(msg: string): void {
         let foundSpell: SpellDefinition | undefined = this.searchSpellFromMessageBegining(msg);
-        if (!foundSpell)
+        if (!foundSpell || !foundSpell.CastingPhrase)
             return;
 
         // Just to avoid detecting name in spell name
-        let msgWithoutSpellName = msg.substring(msg.indexOf(foundSpell.Name));
+        let msgWithoutSpellName = msg.substring(msg.indexOf(foundSpell.CastingPhrase));
 
         // Now get all player name mentionned in message
         let targetCharacterList: Character[] = this.getFirstCharactersFromMessage(msgWithoutSpellName);
@@ -882,10 +882,10 @@ export class MagicModule extends BaseModule {
 
     searchSpellFromMessageBegining(msg: string): SpellDefinition | undefined {
         for (let s of this.AvailableSpells) {
-            if (msg.length <= s.Name.length)
+            if (!s.CastingPhrase || msg.length <= s.CastingPhrase.length)
                 continue;
-            // Work only if msg start with spellName (+ start at position 2 to allow it when aroused)
-            if (msg.startsWith(s.Name) || msg.startsWith(s.Name, 2)) {
+            // Work only if msg start with spellName (+ start at position 2 to allow it when horny talk)
+            if (msg.startsWith(s.CastingPhrase) || msg.startsWith(s.CastingPhrase, 2)) {
                 return s;
             }
         }

--- a/src/Modules/states.ts
+++ b/src/Modules/states.ts
@@ -18,6 +18,7 @@ import { getModule } from "modules";
 import { ItemUseModule } from "./item-use";
 import { ResizedState } from "./States/ResizedState";
 import { BuffedState } from "./States/BuffedState";
+import { BarrierState } from "./States/BarrierState";
 import { PolymorphedState } from "./States/PolymorphedState";
 import { XRayVisionState } from "./States/XRayVisionState";
 import { DeniedState } from "./States/DeniedState";
@@ -76,6 +77,7 @@ export class StateModule extends BaseModule {
     RedressedState: RedressedState;
     PolymorphedState: PolymorphedState;
     BuffedState: BuffedState;
+    BarrierState: BarrierState;
     ArousalPairedState: ArousalPairedState;
     OrgasmSiphonedState: OrgasmSiphonedState;
     XRayState: XRayVisionState;
@@ -107,6 +109,7 @@ export class StateModule extends BaseModule {
         this.RedressedState = new RedressedState(this);
         this.PolymorphedState = new PolymorphedState(this);
         this.BuffedState = new BuffedState(this);
+        this.BarrierState = new BarrierState(this);
         this.ArousalPairedState = new ArousalPairedState(this);
         this.OrgasmSiphonedState = new OrgasmSiphonedState(this);
         this.XRayState = new XRayVisionState(this);
@@ -126,6 +129,7 @@ export class StateModule extends BaseModule {
             this.ArousalPairedState,
             this.OrgasmSiphonedState,
             this.BuffedState,
+            this.BarrierState,
             this.XRayState
         ];
         

--- a/src/Settings/Models/magic.ts
+++ b/src/Settings/Models/magic.ts
@@ -58,6 +58,7 @@ export interface PolymorphConfig extends ItemBundleConfig {
 
 export interface SpellDefinition {
     Name: string;
+    CastingPhrase?: string;
     Creator: number;
     Effects: LSCGSpellEffect[];
     AllowPotion: boolean;

--- a/src/Settings/Models/magic.ts
+++ b/src/Settings/Models/magic.ts
@@ -21,6 +21,7 @@ export enum LSCGSpellEffect {
     polymorph = "Polymorph",
     dispell = "Dispell",
     xRay = "X-Ray Vision",
+    barrier = "Magic Barrier",
     denial = "Denying",
     orgasm = "Forced Orgasm"
 }

--- a/src/Settings/Models/magic.ts
+++ b/src/Settings/Models/magic.ts
@@ -22,6 +22,7 @@ export enum LSCGSpellEffect {
     dispell = "Dispell",
     xRay = "X-Ray Vision",
     barrier = "Magic Barrier",
+    disarm = "Disarming",
     denial = "Denying",
     orgasm = "Forced Orgasm"
 }

--- a/src/Settings/magic.ts
+++ b/src/Settings/magic.ts
@@ -737,6 +737,8 @@ export class GuiMagic extends GuiSubscreen {
 				return "Polymorph the target's body and/or cosplay items";
 			case LSCGSpellEffect.xRay:
 				return "Grants the target X-Ray vision";
+			case LSCGSpellEffect.barrier:
+				return "Create a magic barrier that protect and reflect incoming spell";
 			case LSCGSpellEffect.none:
 			default:
 				return ""			;

--- a/src/Settings/magic.ts
+++ b/src/Settings/magic.ts
@@ -739,6 +739,8 @@ export class GuiMagic extends GuiSubscreen {
 				return "Grants the target X-Ray vision";
 			case LSCGSpellEffect.barrier:
 				return "Create a magic barrier that protect and reflect incoming spell";
+			case LSCGSpellEffect.disarm:
+				return "Disarm the target";
 			case LSCGSpellEffect.none:
 			default:
 				return ""			;

--- a/src/Settings/magic.ts
+++ b/src/Settings/magic.ts
@@ -98,6 +98,14 @@ export class GuiMagic extends GuiSubscreen {
 						setSetting: (val) => { if (!!this.Spell) this.Spell.Name = val},
 						hidden: !this.Spell
 					},<Setting>{
+						type: "text",
+						label: "Casting phrase:",
+						description: "Phrase/word to cast your spell by typing <Casting phrase> <target Name> in the chat.",
+						id: "spellCastingPhrase",
+						setting: () => this.Spell?.CastingPhrase ?? "",
+						setSetting: (val) => { if (!!this.Spell) this.Spell.CastingPhrase = val},
+						hidden: !this.Spell
+					},<Setting>{
 						type: "checkbox",
 						label: "Allow Potion:",
 						description: "Allows this spell to be brewed into a crafted potion bottles/glasses/mugs using its name.",

--- a/src/club_existing/type-overrides.d.ts
+++ b/src/club_existing/type-overrides.d.ts
@@ -31,7 +31,7 @@ type LSCGMessageModelType = "init" | "sync" | "command" | "broadcast";
 
 type LSCGCommandName = "debug" | "grab" | "release" | "remote" | "escape" | "collar-tighten" | "collar-loosen" | "collar-stats" | "photo" | "spell" | "spell-teach" | "pair" | "unpair" | "pairing-update" | "get-spell" | "get-spell-response" | "get-suggestions" | "get-suggestions-response" | "set-suggestions" | "add-leashing" | "remove-leashing" | "craft-share";
 
-type LSCGState = "none" | "hypnotized" | "asleep" | "horny" | "choking" | "held" | "blind" | "deaf" | "frozen" | "gagged" | "redressed" | "arousal-paired" | "orgasm-siphoned" | "leashed" | "resized" | "buffed" | "polymorphed" | "x-ray-vision" | "denied";
+type LSCGState = "none" | "hypnotized" | "asleep" | "horny" | "choking" | "held" | "blind" | "deaf" | "frozen" | "gagged" | "redressed" | "arousal-paired" | "orgasm-siphoned" | "leashed" | "resized" | "buffed" | "polymorphed" | "x-ray-vision" | "denied" | "protected";
 
 type LSCGImmersiveOption = "true" | "false" | "whenImmersive";
 


### PR DESCRIPTION
**New Magic barrier spell effect:**
- Add +5 defense against incoming spell
- If saved against incoming spell the barrier will send the spell back to the sender !
- If not saved, the Player will still suffer from the incoming spell
- The magic barrier is one time use only, whether the player has saved against the spell or not, the magic barrier will disapear after.

**New Disarm spell effect:**
- remove the hand held item fo the target

**New Voice casting ability:**
- Ability to cast spell by sending normal message in chat: `<SpellName> <TargetName>`
- Limited to only one target
- Wand not requiered

If any change are required, let me know!
Azer #172401