### PR TITLE
MAINT: Adapt the share-craft-button to the R111 dialog mode rework

### DIFF
--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -196,23 +196,13 @@ export class ActivityModule extends BaseModule {
                 return next(args);
             }, ModuleCategory.Activities);
         } else { // R111
-            hookFunction("DialogMenuMapping.activities.Reload", 0, (args, next) => {
-                return next(args).then((status: boolean) => {
-                    if (!status || !args[2]?.reset) {
-                        return status;
-                    }
-
-                    const grid = document.getElementById(DialogMenuMapping.activities.ids.grid);
-                    (grid?.querySelectorAll("img.button-image[src*='LSCG']") as NodeListOf<HTMLImageElement>).forEach(img => {
-                        let activityName = img.src.substring(img.src.indexOf("LSCG_"));
-                        activityName = activityName.substring(0, activityName.indexOf(".png"));
-                        const src = this.CustomImages.get(activityName);
-                        if (src) {
-                            img.src = src;
-                        }
-                    });
-                    return status;
-                });
+            hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
+                const activity: ItemActivity = args[1];
+                if (activity.Activity.Name.includes("LSCG")) {
+                    args[4] ??= {}; // null | { image?: string }
+                    args[4].image = this.CustomImages.get(activity.Activity.Name);
+                }
+                return next(args);
             });
         }
 

--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -59,6 +59,9 @@ export interface ActivityBundle extends ActivityBundleBase {
     Targets?: ActivityTarget[];
 }
 
+// >= R111
+declare var DialogMenuMapping: { activities: ScreenFunctions & { ids: { grid: string } } };
+
 export class ActivityModule extends BaseModule {
     get settings(): ActivitySettingsModel {
 		return super.settings as ActivitySettingsModel;
@@ -177,20 +180,41 @@ export class ActivityModule extends BaseModule {
             }
         })
 
-        hookFunction("DrawImageResize", 1, (args, next) => {
-            try {
-                var path = <string>args[0];
-                if (!!path && (typeof path === "string") && path.indexOf("LSCG_") > -1) {
-                    var activityName = path.substring(path.indexOf("LSCG_"));
-                    activityName = activityName.substring(0, activityName.indexOf(".png"))
-                    if (this.CustomImages.has(activityName))
-                        args[0] = this.CustomImages.get(activityName);
+        if (GameVersion === "R110") {
+            hookFunction("DrawImageResize", 1, (args, next) => {
+                try {
+                    var path = <string>args[0];
+                    if (!!path && (typeof path === "string") && path.indexOf("LSCG_") > -1) {
+                        var activityName = path.substring(path.indexOf("LSCG_"));
+                        activityName = activityName.substring(0, activityName.indexOf(".png"))
+                        if (this.CustomImages.has(activityName))
+                            args[0] = this.CustomImages.get(activityName);
+                    }
+                } catch (error) {
+                    console.debug(error);
                 }
-            } catch (error) {
-                console.debug(error);
-            }
-            return next(args);
-        }, ModuleCategory.Activities)
+                return next(args);
+            }, ModuleCategory.Activities);
+        } else { // R111
+            hookFunction("DialogMenuMapping.activities.Reload", 0, (args, next) => {
+                return next(args).then((status: boolean) => {
+                    if (!status || !args[2]?.reset) {
+                        return status;
+                    }
+
+                    const grid = document.getElementById(DialogMenuMapping.activities.ids.grid);
+                    (grid?.querySelectorAll("img.button-image[src*='LSCG']") as NodeListOf<HTMLImageElement>).forEach(img => {
+                        let activityName = img.src.substring(img.src.indexOf("LSCG_"));
+                        activityName = activityName.substring(0, activityName.indexOf(".png"));
+                        const src = this.CustomImages.get(activityName);
+                        if (src) {
+                            img.src = src;
+                        }
+                    });
+                    return status;
+                });
+            });
+        }
 
         hookFunction("CharacterItemsForActivity", 1, (args, next) => {
 			let C = args[0];

--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -16,6 +16,9 @@ import { StateModule } from "./states";
 import { drawTooltip } from "Settings/settingUtils";
 import { GrabType, LeashingModule } from "./leashing";
 
+// >= R111
+declare var DialogMenuMapping: { items: ScreenFunctions & { C: null | Character } };
+
 // Core Module that can handle basic functionality like server handshakes etc.
 export class CoreModule extends BaseModule {
 
@@ -23,7 +26,8 @@ export class CoreModule extends BaseModule {
         x: 1898,
         y: 120,
         width: 40,
-        height: 40
+        height: 40,
+        id: "lscg-share-crafts",
     };
 
     get publicSettings(): IPublicSettingsModel {
@@ -134,38 +138,93 @@ export class CoreModule extends BaseModule {
             }
         }, ModuleCategory.Core);
 
-        hookFunction("DialogDrawItemMenu", 1, (args, next) => {
-            this._drawShareToggleButton(this.toggleSharedButton.x, this.toggleSharedButton.y, this.toggleSharedButton.width, this.toggleSharedButton.height);
-            next(args);
-        }, ModuleCategory.Core);
+        if (GameVersion !== "R110") { // >= R111
+            const loadHook = () => {
+                const elem = document.getElementById(this.toggleSharedButton.id);
+                if (elem) {
+                    elem.style.display = "";
+                    return;
+                }
 
-        hookFunction("DrawItemPreview", 1, (args, next) => {
-				const ret = next(args);
-				const [item, , x, y] = args;
-				if (item) {
-					const { Craft } = item;
-					if (MouseIn(x, y, DialogInventoryGrid.itemWidth, DialogInventoryGrid.itemHeight) && Craft && Craft?.MemberNumber) {
-						drawTooltip(1000, y - 140, 975, `Crafted By: ${Craft.MemberName} [${Craft.MemberNumber}]`, "left");
-					}
-				}
-				return ret;
-			}
-		);
+                const coreModule = this;
+                ElementButton.Create(
+                    this.toggleSharedButton.id,
+                    function () {
+                        const C = DialogMenuMapping.items.C;
+                        if (!C)
+                            return;
 
-        hookFunction("DialogClick", 1, (args, next) => {
-            next(args);
-            let C = CharacterGetCurrent();
-            if (!C)
-                return;
-            if (MouseIn(this.toggleSharedButton.x, this.toggleSharedButton.y, this.toggleSharedButton.width, this.toggleSharedButton.height) &&
-                DialogModeShowsInventory() && (DialogMenuMode === "permissions" || (Player.CanInteract() && !InventoryGroupIsBlocked(C, undefined, true)))) {
-                this.settings.seeSharedCrafts = !this.settings.seeSharedCrafts;
-                settingsSave();
-                DialogInventoryBuild(C, true, false);
+                        coreModule.settings.seeSharedCrafts = this.getAttribute("aria-checked") === "true";
+                        settingsSave();
+                        // @ts-expect-error: R111 added a fourth parameter; remove this comment once R111 annotations are available
+                        DialogInventoryBuild(C, true, false, false);
+                    },
+                    { image: "Icons/Online.png", role: "checkbox", tooltip: "Toggle Shared Crafts", tooltipPosition: "left" },
+                    { button: { parent: document.body, attributes: { "aria-checked": this.settings.seeSharedCrafts } } },
+                );
+            };
+
+            hookFunction("DialogMenuMapping.items.Load", 0, (args, next) => {
+                const ret = next(args);
+                loadHook();
+                return ret;
+            });
+
+            hookFunction("DialogMenuMapping.items.Resize", 0, (args, next) => {
+                ElementPositionFixed(this.toggleSharedButton.id, this.toggleSharedButton.x, this.toggleSharedButton.y, this.toggleSharedButton.width, this.toggleSharedButton.height);
+                return next(args);
+            });
+
+            hookFunction("DialogMenuMapping.items.Exit", 0, (args, next) => {
+                ElementRemove(this.toggleSharedButton.id);
+                return next(args);
+            });
+
+            hookFunction("DialogMenuMapping.items.Unload", 0, (args, next) => {
+                const elem = document.getElementById(this.toggleSharedButton.id);
+                if (elem) { elem.style.display = "none"; }
+                return next(args);
+            });
+
+            // Manually fire up the load hook if the dialog-items sub screen is already open upon loading LSCG
+            if (DialogMenuMode === "items") {
+                loadHook();
             }
-        });
+        } else { // R110
+            hookFunction("DialogDrawItemMenu", 1, (args, next) => {
+                this._drawShareToggleButton(this.toggleSharedButton.x, this.toggleSharedButton.y, this.toggleSharedButton.width, this.toggleSharedButton.height);
+                next(args);
+            }, ModuleCategory.Core);
+
+            hookFunction("DrawItemPreview", 1, (args, next) => {
+                    const ret = next(args);
+                    const [item, , x, y] = args;
+                    if (item) {
+                        const { Craft } = item;
+                        if (MouseIn(x, y, DialogInventoryGrid.itemWidth, DialogInventoryGrid.itemHeight) && Craft && Craft?.MemberNumber) {
+                            drawTooltip(1000, y - 140, 975, `Crafted By: ${Craft.MemberName} [${Craft.MemberNumber}]`, "left");
+                        }
+                    }
+                    return ret;
+                }
+            );
+
+            hookFunction("DialogClick", 1, (args, next) => {
+                next(args);
+                let C = CharacterGetCurrent();
+                if (!C)
+                    return;
+                if (MouseIn(this.toggleSharedButton.x, this.toggleSharedButton.y, this.toggleSharedButton.width, this.toggleSharedButton.height) &&
+                    DialogModeShowsInventory() && (DialogMenuMode === "permissions" || (Player.CanInteract() && !InventoryGroupIsBlocked(C, undefined, true)))) {
+                    this.settings.seeSharedCrafts = !this.settings.seeSharedCrafts;
+                    settingsSave();
+                    DialogInventoryBuild(C, true, false);
+                }
+            });
+        }
     }
 
+    // R110
     _drawShareToggleButton(X: number, Y: number, Width: number, Height: number) {
         DrawButton(X, Y, Width, Height, "", this.settings.seeSharedCrafts ? "White" : "Red", "", "Toggle Shared Crafts", false);
         DrawImageResize("Icons/Online.png", X + 2, Y + 2, Width - 4, Height - 4);
@@ -245,7 +304,7 @@ export class CoreModule extends BaseModule {
                         break;
                 }
             }
-            
+
         }
     }
 


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5278](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5278)

Above-mentioned PR overhauls the UI of a number of dialog menu modes (including the `items` mode) for R111, which would render the LSCG share-craft button stuck and unclickable behind the new subscreen's bew DOM elements. This issue is fixed herein by also converting the relevant LSCG button into a DOM element and hooking into the new API.

Includes changes both suitable for the beta-period and full R111 release.

Marking as draft for now until the upstream PR has been merged.

Examples
---------

https://github.com/user-attachments/assets/c733af77-ef74-464d-ba7c-7471594e8f60


