### PR TITLE
Fix for selftightening item that remove locks (issue #594)

### DIFF
--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1332,8 +1332,6 @@ export class ItemUseModule extends BaseModule {
 				let itemUpdate = Player.Appearance.find(i => i.Asset.Name == item?.Asset.Name);
 				if (!!itemUpdate) {
 					itemUpdate.Difficulty = (itemUpdate.Difficulty ?? 0) + 5;
-					if (!!itemUpdate.Property)
-						itemUpdate.Property.Difficulty = (itemUpdate.Property.Difficulty ?? 0) + 5;
 				}
 				
 				if (item.Asset.Group.Name == "ItemNeck" && getModule<CollarModule>("CollarModule").WearingCorrectCollar(Player)) {


### PR DESCRIPTION
This fix issue #594

For some reason, the game code don't like when changing the difficulty in item.Property.Difficulty, it always seems to trigger the function ValidationSanitizeProperties() from the base game code. Even when trying to set this property with function like ExtendedItemSetProperty() the result is the same.

On the other hand, only setting item.Difficulty seem to works fine, i don't think the other one is being used for the difficulty calculation, even when it exist.

Note also: this bug not only remove locks, but it seem to also reset some options on an ExtendedItem.
