### PR TITLE
BETA: Ensure that the group name is passed along when constructing `ItemActivity` objects

### DIFF
--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -159,7 +159,7 @@ export class CoreModule extends BaseModule {
                         // @ts-expect-error: R111 added a fourth parameter; remove this comment once R111 annotations are available
                         DialogInventoryBuild(C, true, false, false);
                     },
-                    { image: "Icons/Online.png", role: "checkbox", tooltip: "Toggle Shared Crafts", tooltipPosition: "left" },
+                    { image: "./Icons/Online.png", role: "checkbox", tooltip: "Toggle Shared Crafts", tooltipPosition: "left" },
                     { button: { parent: document.body, attributes: { "aria-checked": this.settings.seeSharedCrafts } } },
                 );
             };

--- a/src/club_existing/bc/Typedef.d.ts
+++ b/src/club_existing/bc/Typedef.d.ts
@@ -967,6 +967,8 @@ type ItemActivityRestriction = "blocked" | "limited" | "unavail";
 interface ItemActivity {
 	/** The activity performed */
 	Activity: Activity;
+	/** The target group of the activity */
+	Group: AssetGroupName;
 	/** An optional item used for the activity. Null if the player is used their hand, for example. */
 	Item?: Item;
 	/** Whether the item is blocked or limited on the target character, or unavailable because the player is blocked. Undefined means no restriction. */


### PR DESCRIPTION
Small follow up on https://github.com/littlesera/LSCG/pull/596 with a change I had forgotten to take into account:

The `ItemActivity` object now has a new `Group` parameter (representing the target group of the activity), a group which, as of this PR, is now properly passed along in the `ManualGenerateItemActivitiesForNecklaceActivity()`.