### PR TITLE
Chaotic items: Added ability to add 'quick' and 'slow' keyword

### DIFF
--- a/src/Settings/global.ts
+++ b/src/Settings/global.ts
@@ -131,8 +131,8 @@ export class GuiGlobal extends GuiSubscreen {
 				disabled: !this.settings.enabled
 			},<Setting>{
 				type: "checkbox",
-				label: "Enable Chaotic Items:",
-				description: "Enable chaotic features on crafted items you wear.",
+				label: "Enable Chaotic/Evolving Items:",
+				description: "Enable chaotic/evolving features on crafted items you wear.",
 				setting: () => Player.LSCG.ChaoticItemModule.enabled ?? true,
 				setSetting: (val) => Player.LSCG.ChaoticItemModule.enabled = val,
 				disabled: !this.settings.enabled


### PR DESCRIPTION
Chaotic items: Added ability to add 'quick' and 'slow' keyword to reduce or increase the trigger time. (New trigger time: default=10min quick=3min slow=30min)

- New default time: 10min
- Quick keywords reduce the trigger time to 3min
	- Quick keywords: "quick", "quickly", "rapidly", "fast"
- Slow keywords increase the trigger time to 30min
	- Slow keywords: "slow", "slowly"