### PR TITLE
Chaotic items refactoring and small fixes

### DIFF
--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -463,7 +463,7 @@ export class ChaoticItemModule extends BaseModule {
 
         // Change item's option based on the logic provided (random or evolving)
         // evolving logic will select a higher indexed option (or do nothing if nothing higher)
-        let logic: "random" | "evolving" = "random";
+        let logic: ChangeLogic = "random";
         let itemStr = GetItemNameAndDescriptionConcat(item) ?? "";
         if (evolvingKeywords.some(k => isPhraseInString(itemStr, k)))
             logic = "evolving";
@@ -491,7 +491,7 @@ export class ChaoticItemModule extends BaseModule {
         }
     }
 
-    shapeShiftTypedItem(item: Item, logic: "random" | "evolving"): boolean {
+    shapeShiftTypedItem(item: Item, logic: ChangeLogic): boolean {
         // Mostly copied from TypedItemSetRandomOption implementation
         const typedData = TypedItemDataLookup[`${item.Asset.Group.Name}${item.Asset.Name}`];
         //console.log("shapeshiftTypedItem: typedData: ", typedData);
@@ -536,7 +536,7 @@ export class ChaoticItemModule extends BaseModule {
     **** Modular item's functions ****
     */
 
-    shapeShiftModularItem(item: Item, logic: "random" | "evolving"): boolean {
+    shapeShiftModularItem(item: Item, logic: ChangeLogic): boolean {
         let ret = false;
         const modularData = ModularItemDataLookup[`${item.Asset.Group.Name}${item.Asset.Name}`];
         //console.log("shapeShiftModularItem: modularData: ", modularData);
@@ -589,7 +589,7 @@ export class ChaoticItemModule extends BaseModule {
     }
 
 
-    changeModuleOption(item: Item, modularData: ModularItemData, modularModule: ModularItemModule, moduleIndex: number, logic: "random" | "evolving"): boolean {
+    changeModuleOption(item: Item, modularData: ModularItemData, modularModule: ModularItemModule, moduleIndex: number, logic: ChangeLogic): boolean {
         // get previous option
         let itemTypeRecord: TypeRecord | undefined | null = item.Property?.TypeRecord;
         if (!itemTypeRecord)
@@ -650,7 +650,7 @@ export class ChaoticItemModule extends BaseModule {
     **** Vibrator item's functions ****
     */
 
-    shapeShiftVibratorItem(item: Item, logic: "random" | "evolving"): boolean {
+    shapeShiftVibratorItem(item: Item, logic: ChangeLogic): boolean {
         const vibratorData = VibratorModeDataLookup[`${item.Asset.Group.Name}${item.Asset.Name}`];
         //console.log("shapeShiftVibratorItem: VIBRATING: vibratorData: ", vibratorData);
 

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -358,7 +358,7 @@ export class ChaoticItemModule extends BaseModule {
     // Change specific properties that are part of the options of an item
     // This is based on itemData.baselineProperty that provide us all special properties of an item
     changeEditableProperty(item: Item, itemData: TypedItemData | ModularItemData | VibratingItemData, logic: "random" | "evolving"): boolean {
-        let newProperty: ItemProperties | undefined = CommonCloneDeep(item.Property);;
+        let newProperty: ItemProperties | undefined = CommonCloneDeep(item.Property);
         let propertyChanged: boolean = false;
         if (!item.Property || !newProperty) {
             console.warn("changeEditableProperty: item.Property or newProperty is undefined !");
@@ -569,7 +569,7 @@ export class ChaoticItemModule extends BaseModule {
                 return obj.PunishRequiredSpeechWord;
             default:
                 return undefined;
-        };
+        }
     }
 
     // Workaround to bypass TS custom type
@@ -611,7 +611,7 @@ export class ChaoticItemModule extends BaseModule {
             case "PunishRequiredSpeechWord":
                 obj.PunishRequiredSpeechWord = value;
                 break;
-        };
+        }
         return obj;
     }
 

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -671,31 +671,26 @@ export class ChaoticItemModule extends BaseModule {
         let vibratorPrevOptionName = item.Property?.Mode;
         if (logic == "evolving" && vibratorPrevOptionName) {
             // find current/previous option index
-            let previousOptionIndex = undefined;
-            let i = 0;
-            while (i < vibratorAvailableOptions.length) {
-                let option = vibratorAvailableOptions[i];
-                if (option.Name == vibratorPrevOptionName) {
-                    previousOptionIndex = i;
-                    break;
-                }
-                i++;
-            }
-            if (!previousOptionIndex) {
+            const previousOptionIndex = vibratorAvailableOptions.findIndex(option => option.Name === vibratorPrevOptionName);
+
+            if (previousOptionIndex < 0) {
                 console.warn("shapeShiftVibratorItem: Couldn't find previous option with vibratorPrevOptionName=" + vibratorPrevOptionName + " vibratorAvailableOptions: ", vibratorAvailableOptions);
                 return false;
             }
 
-            if (previousOptionIndex == (vibratorAvailableOptions.length - 1)) {
+            if (previousOptionIndex === (vibratorAvailableOptions.length - 1)) {
                 // We're already using the last option, Nothing to do.
                 return true;
             }
+
+            vibratorNewOption = vibratorAvailableOptions[previousOptionIndex + 1].Name;
         } else {
             // random logic
             let maxRandom = vibratorAvailableOptions.length;
             let vibratorOptionIndex = Math.floor(Math.random() * maxRandom);
             vibratorNewOption = vibratorAvailableOptions[vibratorOptionIndex].Name;
         }
+
         if (!vibratorNewOption) {
             return false;
         }

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -444,8 +444,8 @@ export class ChaoticItemModule extends BaseModule {
                     }
                     // 0 | 1 | 2 | 3 properties
                     else if (["AutoPunish", "PunishSpeech", "PunishProhibitedSpeech", "PunishRequiredSpeech"].includes(property)) {
-                        let currentNumber = this.getItemPropertyValueFromObject(item.Property, property);
-                        if (currentNumber && typeof currentNumber == "number" && currentNumber < 3) {
+                        const currentNumber = this.getNumericPropertyFromObject(item.Property, property);
+                        if (currentNumber !== undefined && currentNumber < 3) {
                             newProperty = this.setItemPropertyValue(newProperty, property, currentNumber + 1);
                             newValuestr = (currentNumber+1).toString();
                             // Special case
@@ -526,6 +526,14 @@ export class ChaoticItemModule extends BaseModule {
     getItemPropertyValueFromObject(obj: PropertiesNoArray | ItemProperties, property: string) {
         if (property in obj) {
             return obj[property as keyof typeof obj];
+        }
+        return undefined;
+    }
+
+    getNumericPropertyFromObject(obj: PropertiesNoArray | ItemProperties, property: string): number | undefined {
+        const value = this.getItemPropertyValueFromObject(obj, property);
+        if (typeof value === "number") {
+            return value;
         }
         return undefined;
     }

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -369,7 +369,7 @@ export class ChaoticItemModule extends BaseModule {
         }
 
         let selectedProperty: string | undefined = undefined;
-        let newValuestr: any = undefined;
+        let newValuestr = '<hidden>';
         if (existingProperty.length > 0) {
             //console.log("changeEditableProperty: existingProperty: ", existingProperty);
             if (logic == 'random') {
@@ -393,14 +393,9 @@ export class ChaoticItemModule extends BaseModule {
 
                 // boolean properties
                 if (["PunishActivity", "PunishOrgasm", "PunishStandup", "PunishStruggle", "PunishStruggleOther"].includes(selectedProperty)) {
-                    if (selectedProperty in item.Property && this.getItemPropertyValueFromObject(item.Property, selectedProperty)) {
-                        newProperty = this.setItemPropertyValue(newProperty, selectedProperty, false);
-                        newValuestr = "false";
-                    }
-                    else {
-                        newProperty = this.setItemPropertyValue(newProperty, selectedProperty, true);
-                        newValuestr = "true";
-                    }
+                    const newValue = !(selectedProperty in item.Property && this.getItemPropertyValueFromObject(item.Property, selectedProperty));
+                    newProperty = this.setItemPropertyValue(newProperty, selectedProperty, newValue);
+                    newValuestr = newValue.toString();
                     propertyChanged = true;
                 }
                 // 0 | 1 | 2 | 3 properties
@@ -422,7 +417,6 @@ export class ChaoticItemModule extends BaseModule {
                 else if (selectedProperty == "TriggerValues" &&  itemData.baselineProperty?.TriggerValues) {
                     const newTriggerValues = this.randomizeTriggerValues(itemData.baselineProperty.TriggerValues);
                     newProperty = this.setItemPropertyValue(newProperty, "TriggerValues", newTriggerValues ?? itemData.baselineProperty.TriggerValues);
-                    newValuestr = "<hidden>";
                     selectedProperty = "voice trigger words";
                     propertyChanged = true;
                 }
@@ -446,13 +440,14 @@ export class ChaoticItemModule extends BaseModule {
                     else if (["AutoPunish", "PunishSpeech", "PunishProhibitedSpeech", "PunishRequiredSpeech"].includes(property)) {
                         const currentNumber = this.getNumericPropertyFromObject(item.Property, property);
                         if (currentNumber !== undefined && currentNumber < 3) {
-                            newProperty = this.setItemPropertyValue(newProperty, property, currentNumber + 1);
-                            newValuestr = (currentNumber+1).toString();
+                            const newValue = currentNumber + 1;
+                            newProperty = this.setItemPropertyValue(newProperty, property, newValue);
+                            newValuestr = newValue.toString();
                             // Special case
-                            if (property == "PunishProhibitedSpeech" &&  itemData.baselineProperty?.PunishProhibitedSpeechWords) {
+                            if (property == "PunishProhibitedSpeech" && itemData.baselineProperty?.PunishProhibitedSpeechWords) {
                                 newProperty = this.setItemPropertyValue(newProperty, "PunishProhibitedSpeechWords", itemData.baselineProperty.PunishProhibitedSpeechWords);
                             }
-                            else if (property == "PunishRequiredSpeech" &&  itemData.baselineProperty?.PunishRequiredSpeechWord) {
+                            else if (property == "PunishRequiredSpeech" && itemData.baselineProperty?.PunishRequiredSpeechWord) {
                                 newProperty = this.setItemPropertyValue(newProperty, "PunishRequiredSpeechWord", itemData.baselineProperty.PunishRequiredSpeechWord);
                             }
                             propertyChanged = true;
@@ -462,7 +457,6 @@ export class ChaoticItemModule extends BaseModule {
                     else if (property == "TriggerValues" &&  itemData.baselineProperty?.TriggerValues) {
                         const newTriggerValues = this.randomizeTriggerValues(itemData.baselineProperty.TriggerValues);
                         newProperty = this.setItemPropertyValue(newProperty, "TriggerValues", newTriggerValues ?? itemData.baselineProperty.TriggerValues);
-                        newValuestr = "<hidden>";
                         selectedProperty = "voice trigger words";
                         propertyChanged = true;
                         break;

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -228,7 +228,7 @@ export class ChaoticItemModule extends BaseModule {
         return ret;
     }
 
-    
+
     changeModuleOption(item: Item, modularData: ModularItemData, modularModule: ModularItemModule, moduleIndex: number, logic: "random" | "evolving"): boolean {
         // get previous option
         let itemTypeRecord: TypeRecord | undefined | null = item.Property?.TypeRecord;
@@ -327,7 +327,7 @@ export class ChaoticItemModule extends BaseModule {
             }
 
             if (previousOptionIndex == (vibratorAvailableOptions.length - 1)) {
-                // We already using the last option, Nothing to do.
+                // We're already using the last option, Nothing to do.
                 return true;
             }
         }
@@ -352,11 +352,11 @@ export class ChaoticItemModule extends BaseModule {
 
 
     /*
-    ***** Functions to change item's properties (i.e. other options not indentified in data's options) *****
+    ***** Functions to change item's properties (i.e. other options not identified in data's options) *****
     */
 
     // Change specific properties that are part of the options of an item
-    // This is based on itemData.baselineProperty that provide us all special proerties of an item
+    // This is based on itemData.baselineProperty that provide us all special properties of an item
     changeEditableProperty(item: Item, itemData: TypedItemData | ModularItemData | VibratingItemData, logic: "random" | "evolving"): boolean {
         let newProperty: ItemProperties | undefined = CommonCloneDeep(item.Property);;
         let propertyChanged: boolean = false;
@@ -366,7 +366,7 @@ export class ChaoticItemModule extends BaseModule {
         }
 
         // Get all the item's property that we can modify
-        // EditableProperty is our handcrafted list of specific properties that we can modifiy
+        // EditableProperty is our handcrafted list of specific properties that we can modify
         let existingProperty: string[] = this.geEditablePropertyInBaseline(itemData.baselineProperty);
         if (existingProperty.length <= 0) {
             return false;
@@ -496,8 +496,8 @@ export class ChaoticItemModule extends BaseModule {
             // Update item
             ExtendedItemSetProperty(Player, item, item.Property, newProperty, true, true);
             let itemName = (item?.Craft?.Name ?? item.Asset.Name);
-            // Idk why but this AssetTextGet almost always fail to retreive the correct text.
-            // And because the string to retreive the asset's text don't follow any logics, we probably cannot do better
+            // Idk why but this AssetTextGet almost always fail to retrieve the correct text.
+            // And because the string to retrieve the asset's text don't follow any logics, we probably cannot do better
             let propertyName = AssetTextGet(item.Asset.Name + selectedProperty) ?? selectedProperty;
             if (propertyName.includes("MISSING")) {
                 propertyName = selectedProperty ?? "unknown property";
@@ -513,7 +513,7 @@ export class ChaoticItemModule extends BaseModule {
         if (!baselineProperty) {
             return [];
         }
-        // editableProperty are others options that are not part of an extended item's options such as chechbox / voice command trigger word
+        // editableProperty are others options that are not part of an extended item's options such as checkbox / voice command trigger word
         let editableProperty = [
             "AutoPunish",
             "PunishActivity",
@@ -614,7 +614,7 @@ export class ChaoticItemModule extends BaseModule {
         };
         return obj;
     }
-    
+
     // Randomize the voice trigger values with our custom list of common word
     // baselineTriggerValues is a list of word separated by commas (type string)
     // baselineTriggerValues also provide us with the information of how much word is needed
@@ -641,7 +641,7 @@ export class ChaoticItemModule extends BaseModule {
             "orgasm",
             "shock",
             "punish",
-            "punishement",
+            "punishment",
             "cute",
             "cutie",
             "slut",
@@ -702,7 +702,7 @@ export class ChaoticItemModule extends BaseModule {
     /*
     ***** Helper functions *****
     */
-    
+
     getNextOptionFromOptionsList<T extends TypedItemOption | ModularItemOption>(currentOption: T, availableOptions: T[]): T | undefined {
         let isNextOption = false;
         let newOption: T | undefined = undefined;
@@ -724,7 +724,7 @@ export class ChaoticItemModule extends BaseModule {
                 return undefined;
             }
             else {
-                // If we didn't found our current used option, just use the last one directly then
+                // If we haven't found our current used option, just use the last one directly then
                 newOption = availableOptions[availableOptions.length - 1];
             }
         }

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -717,7 +717,7 @@ export class ChaoticItemModule extends BaseModule {
             return undefined;
         }
 
-        if (currentOptionIndex <= 0) {
+        if (currentOptionIndex < 0) {
             // If we haven't found our current used option, just use the last one directly then
             return availableOptions[availableOptions.length - 1];
         }


### PR DESCRIPTION
Logic bugs:
- Fixed some numeric properties not evolving from 0 value due to treating it as a boolean;
- Fixed vibrator settings not evolving while spewing console warnings.

Refactoring:
- Extracted property mutation logic to a separate class for readability;
- Changed various small parts of code to be more concise;
- Fixed a few typos.
