### PR TITLE
ENH: Improve the item UI related to chaotic- & evolving-keywords

### DIFF
--- a/src/regEscape.ts
+++ b/src/regEscape.ts
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+core-js 3.40.0 - 2025.01.08
+
+Copyright (c) 2014-2025 Denis Pushkarev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+
+/**
+ * Escapes any potential regex syntax characters in a string, and returns a new string that can be safely used as a literal pattern for the {@link RegExp} constructor.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
+ * @param S The string to escape.
+ * @returns A new string that can be safely used as a literal pattern for the {@link RegExp} constructor. 
+ */
+// Adapted from https://github.com/zloirock/core-js/blob/v3.40.0/packages/core-js/modules/esnext.regexp.escape.js
+export var regEscape = (() => {
+    // As of the time of writing a limited number of browsers have native `RegExp.escape` support
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
+    if ("escape" in RegExp && typeof RegExp.escape === "function") {
+        return RegExp.escape as (S: string) => string;
+    }
+
+    var WHITESPACES = (
+        '\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002' +
+        '\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF'
+    );
+
+    var FIRST_DIGIT_OR_ASCII = /^[0-9a-z]/i;
+    var SYNTAX_SOLIDUS = /^[$()*+./?[\\\]^{|}]/;
+    var OTHER_PUNCTUATORS_AND_WHITESPACES = RegExp('^[!"#%&\',\\-:;<=>@`~' + WHITESPACES + ']');
+    var ControlEscape = {
+        '\u0009': 't',
+        '\u000A': 'n',
+        '\u000B': 'v',
+        '\u000C': 'f',
+        '\u000D': 'r',
+    };
+
+    function escapeChar(chr: string): string {
+        var hex = chr.charCodeAt(0).toString(16);
+        return hex.length < 3 ? '\\x' + hex.padStart(2, '0') : '\\u' + hex.padStart(4, '0');
+    };
+
+    // `RegExp.escape` method
+    // https://github.com/tc39/proposal-regex-escaping
+    return function escape(S: string): string {
+        if (typeof S !== 'string') {
+            throw new TypeError('Argument is not a string');
+        }
+    
+        var length = S.length;
+        var result = Array(length);
+
+        for (var i = 0; i < length; i++) {
+            var chr = S.charAt(i);
+            if (i === 0 && FIRST_DIGIT_OR_ASCII.exec(chr)) {
+                result[i] = escapeChar(chr);
+            } else if (chr in ControlEscape) {
+                result[i] = '\\' + ControlEscape[chr as keyof typeof ControlEscape];
+            } else if (SYNTAX_SOLIDUS.exec(chr)) {
+                result[i] = '\\' + chr;
+            } else if (OTHER_PUNCTUATORS_AND_WHITESPACES.exec(chr)) {
+                result[i] = escapeChar(chr);
+            } else {
+                var charCode = chr.charCodeAt(0);
+                if ((charCode & 0xF800) !== 0xD800) { // single UTF-16 code unit
+                    result[i] = chr;
+                } else if (charCode >= 0xDC00 || i + 1 >= length || (S.charCodeAt(i + 1) & 0xFC00) !== 0xDC00) { // unpaired surrogate
+                    result[i] = escapeChar(chr);
+                } else { // surrogate pair
+                    result[i] = chr;
+                    result[++i] = S.charAt(i);
+                }
+            }
+        }
+
+        return result.join('');
+    };
+})();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import { ModuleCategory } from "Settings/setting_definitions";
 import { clone } from "lodash-es";
 import { SettingsModel } from "Settings/Models/settings";
 import { lt } from "semver";
+import { regEscape } from "./regEscape";
 
 export const LSCG_CHANGES: string = "https://github.com/littlesera/LSCG/releases/latest";
 export const LSCG_TEAL: string = "#00d5d5";
@@ -403,7 +404,7 @@ export function isObject(obj: unknown): obj is Record<string, any> {
 }
 
 export function escapeRegExp(string: string) {
-	return string?.toLocaleLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&') ?? ""; // $& means the whole matched string
+	return regEscape(string ?? "").toLocaleLowerCase();
 }
 
 export function isPhraseInString(string: string, phrase: string, ignoreOOC: boolean = false) {


### PR DESCRIPTION
This PR, serving a bit is a proof of concept, changes a couple of thing related to how LSCG chaotic- and evolving-keywords are presented towards the user:
* Rather then retaining their square brackets, the brackets are now removed and the relevant term is italicized in button labels/tooltips, blending more seamlessly into the rest of the tooltips (square brackets tend to stand out a lot and have a questionable visual appeal) while stile signifying some importance of the respective term. Note that this only affects how things are rendered _after_ equipping the item; the actual crafting config remains and data storage model remain untouched.
* The chaotic- and evolving-keywords are now explicitly added to the "Status & Effects` section of the tooltip. While currently still lacking, there is enough space here to add a proper description and explanation of the keyword in the future (if so desired).

Examples
----------
![craft-lscg](https://github.com/user-attachments/assets/af7c3dfa-59db-4b09-96ea-ce8ffed9c4b0)
