### PR TITLE
Bracketed keyword display fix

### DIFF
--- a/lscgLoader-dev.user.js
+++ b/lscgLoader-dev.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG DEV
 // @namespace https://www.bondageprojects.com/
-// @version 0.5.6
+// @version 0.5.7
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*

--- a/lscgLoader.user.js
+++ b/lscgLoader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name LSCG
 // @namespace https://www.bondageprojects.com/
-// @version 0.5.6
+// @version 0.5.7
 // @description Little Sera's Club Games
 // @author Little Sera
 // @match https://bondageprojects.elementfx.com/*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ls-club-games",
   "description": "Little Sera's Club Games",
-  "version": "0.5.6", 
+  "version": "0.5.7", 
   "main": "dist/bundle.js",
   "scripts": {
     "build": "rollup -c",

--- a/src/Modules/core.ts
+++ b/src/Modules/core.ts
@@ -405,6 +405,7 @@ export class CoreModule extends BaseModule {
 
     ShowChangelog(): void {
         const message = `New LSCG version: ${LSCG_VERSION}
+NOTE: 'Chaotic' and 'Evolving' description tags must use [] brackets now!~
 See below for the latest changes:
 ${LSCG_CHANGES}`;
         ServerAccountBeep({

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -235,7 +235,7 @@ export class MagicModule extends BaseModule {
         return rangedItemKeywords.some(keyword => isPhraseInString(craftStr, keyword));
     }
 
-    CanUseMagic(target: Character, checkMagicItem: boolean = true) {
+    CanUseMagic(target: Character, checkMagicItem: boolean = true, requireHands: boolean = true) {
         let item = InventoryGet(Player, "ItemHandheld");
         let isWieldingMagicItem = (checkMagicItem) ? (!!item && this.IsMagicItem(item)) : true;
         let hasItemPermission = ServerChatRoomGetAllowItem(Player, target);
@@ -245,7 +245,7 @@ export class MagicModule extends BaseModule {
                 targetHasMagicEnabled &&
                 isWieldingMagicItem &&
                 hasItemPermission &&
-                Player.CanInteract() &&
+                (!requireHands || Player.CanInteract()) &&
                 whitelisted &&
                 (this.CanCastSpell(target as OtherCharacter) ||
                 this.CanWildMagic(target as OtherCharacter) ||
@@ -859,7 +859,7 @@ export class MagicModule extends BaseModule {
 
         let foundSpell = spellTargetPair[0];
         let target = spellTargetPair[1];
-        if (!this.CanUseMagic(target, false)) {
+        if (!this.CanUseMagic(target, false, false)) {
             return;
         }
         let pairTgt: Character | undefined;


### PR DESCRIPTION
* Integrate change from @bananarama92 to better display bracketed keywords in crafted item names and descriptions