### PR TITLE
BUG: Fix the spell menu failing to properly exit the dialog subscreen

### DIFF
--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -276,6 +276,8 @@ export class MagicModule extends BaseModule {
         if (this.Enabled) {
             this.SpellMenuOpen = true;
             this.PrevScreen = CurrentScreen;
+            // @ts-expect-error: Requires updated bc stubs
+            DialogMenuMapping.dialog.Unload();
             CurrentScreen = "LSCG_SPELLS_DIALOG";
         }
     }
@@ -286,6 +288,8 @@ export class MagicModule extends BaseModule {
         this.SpellPairOption.SelectOpen = false;
         if (CurrentScreen == "LSCG_SPELLS_DIALOG")
             CurrentScreen = this.PrevScreen ?? "ChatRoom";
+        // @ts-expect-error: Requires updated bc stubs
+        DialogMenuMapping.dialog.Load();
     }
 
     TeachSpell(target: OtherCharacter) {


### PR DESCRIPTION
Closes https://github.com/littlesera/LSCG/issues/636

Fixes the issue below by unloading the relevant dialog screen before opening the spell menu.

Examples
----------
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/3849a859-79e7-41c8-82d7-e542a3435b18" />
