### PR TITLE
BUG: Ensure that the `Steal` activity requires ones hands to be untied

### DIFF
--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -748,7 +748,7 @@ export class ItemUseModule extends BaseModule {
 				Name: "Steal" as ActivityName,
 				MaxProgress: 50,
 				MaxProgressSelf: 50,
-				Prerequisite: ["Needs-AnyItem" as ActivityPrerequisite],
+				Prerequisite: ["Needs-AnyItem" as ActivityPrerequisite, "UseHands"],
 				Reverse: true // acting and acted are flipped!
 			},
 			Targets: [

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -276,6 +276,8 @@ export class MagicModule extends BaseModule {
         if (this.Enabled) {
             this.SpellMenuOpen = true;
             this.PrevScreen = CurrentScreen;
+            // @ts-expect-error: Requires updated bc stubs
+            DialogMenuMapping.dialog.Unload();
             CurrentScreen = "LSCG_SPELLS_DIALOG";
         }
     }
@@ -286,6 +288,8 @@ export class MagicModule extends BaseModule {
         this.SpellPairOption.SelectOpen = false;
         if (CurrentScreen == "LSCG_SPELLS_DIALOG")
             CurrentScreen = this.PrevScreen ?? "ChatRoom";
+        // @ts-expect-error: Requires updated bc stubs
+        DialogMenuMapping.dialog.Load();
     }
 
     TeachSpell(target: OtherCharacter) {


### PR DESCRIPTION
Previously you could still steal an item while fully tied up, which could get a little bit silly.