### PR TITLE
BUG: Fix the LSCG display craft feature failing to decode extended craft descriptions

### DIFF
--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1541,7 +1541,7 @@ export class ItemUseModule extends BaseModule {
 	}
 
 	DisplayCraft(craft: CraftingItem) {
-		SendAction(`%NAME% holds up %POSSESSIVE% ${craft.Name} to the room` + (!!craft.Description ? `: ${craft.Description}` : ""));
+		SendAction(`%NAME% holds up %POSSESSIVE% ${craft.Name} to the room` + (!!craft.Description ? `: ${CraftingDescription.Decode(craft.Description)}` : ""));
 		sendLSCGMessage(<LSCGMessageModel>{
 			reply: false,
 			type: "broadcast",


### PR DESCRIPTION
Closes https://github.com/littlesera/LSCG/issues/678

Fixes a description decode operation which I originally missed back in https://github.com/littlesera/LSCG/pull/574.