### PR TITLE
BUG: Fix opacity element changes triggering an infinite recursive loop

### DIFF
--- a/src/Modules/opacity.ts
+++ b/src/Modules/opacity.ts
@@ -584,20 +584,20 @@ export class OpacityModule extends BaseModule {
     OpacityChange(slider: OpacitySlider) {
         let value = Math.round(this._updateOpacityValue(slider.ElementId) * 100);
         slider.Value = value;
-        ElementValue(slider.ElementId + "_Text", value + "");
+        document.getElementById(slider.ElementId + "_Text")?.setAttribute("value", value);
         this.UpdatePreview();
     }
 
     OpacityTextChange(slider: OpacitySlider) {
         let value = Math.round(this._updateOpacityValue(slider.ElementId + "_Text") * 100);
         slider.Value = value;
-        ElementValue(slider.ElementId, value + "");
+        document.getElementById(slider.ElementId)?.setAttribute("value", value);
         this.UpdatePreview();
     }
 
     TranslationTextChange(elementId: string) {
         let value = Math.round(this._updateTranslationValue(elementId));
-        ElementValue(elementId, value + "");
+        document.getElementById(elementId)?.setAttribute("value", value);
         this.UpdatePreview();
     }
 


### PR DESCRIPTION
Ever since R115 the [`ElementValue()`](https://gitgud.io/BondageProjects/Bondage-College/-/blob/607b4bf1852e171c909390c1cb0eae11e654fb3f/BondageClub/Scripts/Element.js#L3-22) function dispatches an `input` event whenever using it to set a value. This runs into a problem with a few LSCG functions, namely those with input event listeners that use `ElementValue()` to further modify their own input values, thus triggering nasty infinite recursion loops.