### PR TITLE
Fix cursed items: Filter out bad/invalid items in outfit (causing infinite loop)

### DIFF
--- a/src/Modules/States/CursedItemState.ts
+++ b/src/Modules/States/CursedItemState.ts
@@ -283,7 +283,8 @@ export class CursedItemState extends BaseState {
 
             //  2b) Compare active outfit code against Player.Appearance, identify any items missing from current wear
             let itemsToApply = outfitItems.filter(bundle => {
-                    return this.itemIsAllowed(bundle, cursedItem.Crafter) &&                                                 // Item allowed to apply
+                    return AssetGet(Player.AssetFamily, bundle.Group, bundle.Name) != null &&   // Filter out bad/invalid item
+                    this.itemIsAllowed(bundle, cursedItem.Crafter) &&   // Item allowed to apply
                     (!this.Inexhaustable(cursedItem) || bundle.Group != keyItem.Asset.Group.Name) &&    // Item not key item if inexhaustable (leave key item behind if overlap)
                     !otherWornCursedOutfitItemGroups.includes(bundle.Group) &&
                     !wornItems.some(item => this.itemBundleMatch(bundle, item))


### PR DESCRIPTION
Filter out bad/invalid items in outfit when applying item for cursed items.

I had an infinite apply loop on a bad/invalid/old item that was on an outfit.

Note that this is hard to reproduce as when you try to import the outfit into lscg outfit collection, lscg automatically corect the outfit (and outfit code). So i could only reproduce it on an outfit i had already for some time.

For reference, this is the bad item:
  {
    "Name": "Rings",
    "Group": "RightHand",        <=== Should be "HandAccessoryRight" instead
    "Color": ...
     .....
}