### PR TITLE
Fix chaotic item trigger only one item

### DIFF
--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -524,7 +524,7 @@ export class ChaoticItemModule extends BaseModule {
 
         let changed = false;
         for (let item of filteredChaoticItems) {
-			changed = changed || this.triggerChaoticItem(item);
+			changed = this.triggerChaoticItem(item) || changed;
         }
 
         if (changed) {


### PR DESCRIPTION
Fix that chaotic item was triggering for only one item instead of all.
Due to most likely typo in the code (code change self explanatory).

Fix issue #702 