### PR TITLE
Fix cursed item color match

### DIFF
--- a/src/Modules/States/CursedItemState.ts
+++ b/src/Modules/States/CursedItemState.ts
@@ -215,13 +215,15 @@ export class CursedItemState extends BaseState {
     ];
 
     getItemColorString(item: ItemBundle | Item) {
-        let itemColor = isString(item.Color) ? item.Color : "";
+        let itemColor = isString(item.Color) ? item.Color : "Default";
         if (isArray(item.Color) && item.Color.length == 1 && item.Color[0] == "Default") {
             itemColor = "Default";
         }
         else if (isArray(item.Color)) {
             itemColor = JSON.stringify(item.Color);
         }
+        if (!itemColor || itemColor == "")
+            itemColor = "Default";
         return itemColor;
     }
 


### PR DESCRIPTION
Fix an issue where some item from the outfit couldn't match with the same worn item, causing infinite apply loop.

In this case the item in outfit didn't have the property color, and the one worn had the color "Default" (i guess bc automatically added it because of the lack of color property).
So equateColor() and getItemColorString() couldn't get a match ("Default" == "").

I'm not sure all cases are covered so more tests might be needed, but it should be better at least.