### PR TITLE
ENH: Add a dedicated icon for LSCG activities

### DIFF
--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -182,31 +182,18 @@ export class ActivityModule extends BaseModule {
             }
         })
 
-        if (GameVersion === "R110") {
-            hookFunction("DrawImageResize", 1, (args, next) => {
-                try {
-                    var path = <string>args[0];
-                    if (!!path && (typeof path === "string") && path.indexOf("LSCG_") > -1) {
-                        var activityName = path.substring(path.indexOf("LSCG_"));
-                        activityName = activityName.substring(0, activityName.indexOf(".png"))
-                        if (this.CustomImages.has(activityName))
-                            args[0] = this.CustomImages.get(activityName);
-                    }
-                } catch (error) {
-                    console.debug(error);
-                }
-                return next(args);
-            }, ModuleCategory.Activities);
-        } else { // R111
-            hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
-                const activity: ItemActivity = args[1];
-                if (activity.Activity.Name.includes("LSCG")) {
-                    args[4] ??= {}; // null | { image?: string }
-                    args[4].image = this.CustomImages.get(activity.Activity.Name);
-                }
-                return next(args);
-            });
-        }
+        hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
+            const activity: ItemActivity = args[1];
+            if (activity.Activity.Name.includes("LSCG")) {
+                args[4] ??= {};
+                args[4].image = this.CustomImages.get(activity.Activity.Name);
+                args[4].icons = [
+                    ...(args[4].icons ?? []),
+                    { name: "lscg", tooltipText: "LSCG activity", iconSrc: ICONS.BOUND_GIRL },
+                ];
+            }
+            return next(args);
+        });
 
         hookFunction("CharacterItemsForActivity", 1, (args, next) => {
 			let C = args[0];


### PR DESCRIPTION
This PR adds a new button icon for LSCG activities. Besides just looking neat, this will make it easier for users to identify where exactly a particular activity originates from (vanilla BC? LSCG? Somewhere else? _etc._); useful for them to know and also very useful info in early debug stages.

Examples
----------
<img width="1119" height="1196" alt="image" src="https://github.com/user-attachments/assets/2361aa20-0808-447b-a2ad-a174830070e1" />
