### PR TITLE
Add an option to disable waking up from trance after hearing a snap

### DIFF
--- a/src/Modules/hypno.ts
+++ b/src/Modules/hypno.ts
@@ -83,6 +83,7 @@ export class HypnoModule extends BaseModule {
             cooldownTime: 0,
             enableArousal: false,
             enableSpirals: true,
+            enableSnapWakeup: true,
             trigger: "",
             triggerRevealed: false,
             triggerTime: 5,
@@ -233,7 +234,11 @@ export class HypnoModule extends BaseModule {
             if ((lowerMsgWords?.indexOf("snaps") ?? -1) >= 0 && 
                 sender?.MemberNumber != Player.MemberNumber &&
                 this.hypnoActivated) {
-                this.TriggerRestoreSnap();
+                if (this.settings.enableSnapWakeup) {
+                    this.TriggerRestoreSnap();
+                } else {
+                    SendAction("%NAME% sways faintly, the snap failing to wake %POSSESSIVE% up.");
+                }
             }
         });
         

--- a/src/Settings/Models/hypno.ts
+++ b/src/Settings/Models/hypno.ts
@@ -34,6 +34,7 @@ export interface HypnoSettingsModel extends HypnoPublicSettingsModel {
     hypnoEyeType: number | undefined;
     enableArousal: boolean;
     enableSpirals: boolean;
+    enableSnapWakeup: boolean;
     stats: HypnoModuleStats;
     triggerCycled: boolean;
     triggerRevealed: boolean;

--- a/src/Settings/hypno.ts
+++ b/src/Settings/hypno.ts
@@ -177,6 +177,13 @@ export class GuiHypno extends GuiSubscreen {
 						setting: () => this.settings.enableSpirals ?? true,
 						setSetting: (val) => this.settings.enableSpirals = val
 					},<Setting>{
+						type: "checkbox",
+						label: "Enable wake-up on snaps:",
+						description: "If checked you exit the trance when you hear someone snapping.",
+						disabled: !this.settings.enabled,
+						setting: () => this.settings.enableSnapWakeup ?? true,
+						setSetting: (val) => this.settings.enableSnapWakeup = val
+					},<Setting>{
 						type: "text",
 						id: "hypno_eyeColor",
 						label: "Hypnotized Eye Color:",


### PR DESCRIPTION
What it says in the title. I have encountered at least one player wishing to roleplay a character who can only snap out of trance with a command, and I suspect some other might appreciate the setting for it too.

By default, this PR retains the old behaviour, not affecting players who don't explicitly disable the setting.
