### PR TITLE
BUG: Fix the `CharacterAppearanceSortLayers()` hook being unable to properly handle array-based opacities

### DIFF
--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -574,8 +574,15 @@ export class OpacityModule extends BaseModule {
             let xray = getModule<StateModule>("StateModule")?.XRayState;
             let xrayActive = xray?.Active && xray?.CanViewXRay(C);
             C.DrawAppearance?.forEach(item => {
-                let opacity = this.getOpacity(item)
-                let hasOpacitySettings = opacity !== undefined && opacity != 1;
+                let opacity = this.getOpacity(item);
+                let hasOpacitySettings = false;
+                if (opacity == null) {
+                    hasOpacitySettings = false;
+                } else if (typeof opacity === "number") {
+                    hasOpacitySettings = item.Asset.Opacity !== opacity;
+                } else if (Array.isArray(opacity)) {
+                    hasOpacitySettings = !opacity.every((opac, i) => opac === item.Asset.Layer[i].Opacity);
+                }
                 if ((hasOpacitySettings || xrayActive) && !item.Property?.LSCGLeadLined) {
                     item.Asset = Object.assign({}, item.Asset);
                     (item.Asset as any).Layer = item.Asset.Layer.map(l => Object.assign({}, l));


### PR DESCRIPTION
Part of https://github.com/littlesera/LSCG/pull/757 involved `OpacityModule.getOpacity()` returning an explicit opacity array for any passed item, while previously a nullish value would be returned in such situation. This would cause the `CharacterAppearanceSortLayers()` hook to trip up, as due to its somewhat lacking opacity array support, it would interpret this as a case of "a custom opacity has been assigned" and accidentally unhide an item that should be hidden.

As a small reproducible example: Equip the ballet boots (`ItemBoots`) and futuristic heels (`Shoes`); opening the color picker for the ballet boots will now always unhide the futuristic heels, causing the two shoe types to be superimposed.