### PR TITLE
Fix crash because of layer count mismatch

### DIFF
--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -576,7 +576,7 @@ export class OpacityModule extends BaseModule {
                 } else if (typeof opacity === "number") {
                     hasOpacitySettings = item.Asset.Opacity !== opacity;
                 } else if (Array.isArray(opacity)) {
-                    hasOpacitySettings = !opacity.every((opac, i) => opac === item.Asset.Layer[i].Opacity);
+                    hasOpacitySettings = !opacity.every((opac, i) => opac === item.Asset.Layer[i]?.Opacity);
                 }
                 if ((hasOpacitySettings || xrayActive) && !item.Property?.LSCGLeadLined) {
                     item.Asset = Object.assign({}, item.Asset);


### PR DESCRIPTION
No idea if the fix is right or not. Might be worth reinvestigating why it would end up trying to load a non-existent layer.

```
Message: Uncaught TypeError: Cannot read properties of undefined (reading 'Opacity')
Source: https://littlesera.github.io/LSCG/bundle.js?v=1763608096110:1:946523
TypeError: Cannot read properties of undefined (reading 'Opacity')
    at https://littlesera.github.io/LSCG/bundle.js?v=1763608096110:1:946523
    at Array.every (<anonymous>)
    at https://littlesera.github.io/LSCG/bundle.js?v=1763608096110:1:946479
    at Array.forEach (<anonymous>)
    at https://littlesera.github.io/LSCG/bundle.js?v=1763608096110:1:946220
    at i (https://sidiousious.gitlab.io/bc-addon-loader/vendor/bcmodsdk.js:10:1426)
    at https://sidiousious.gitlab.io/bc-addon-loader/vendor/bcmodsdk.js:10:2517
    at CharacterLoadCanvas (<url>/Scripts/Character.js:1441:23)
    at i (https://sidiousious.gitlab.io/bc-addon-loader/vendor/bcmodsdk.js:10:1214)
    at https://sidiousious.gitlab.io/bc-addon-loader/vendor/bcmodsdk.js:10:1597
    ```