### PR TITLE
MAINT: Adapt to the R125 crafting effects changes

### DIFF
--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -1441,9 +1441,8 @@ export class ItemUseModule extends BaseModule {
 			var craft = gag.Craft;
 			if (!!craft) {
 				craft.Lock = "";
-				if (craft.Property == "Large" || craft.Property == "Small") {
-					craft.Property = "Normal";
-				}
+				delete craft.Effects.Large;
+				delete craft.Effects.Small;
 			}
 			var color = this._handleWeirdColorStuff(gag, gagTarget, sourceLocation, targetLocation);
 			let item = InventoryWear(source, targetItemName, targetLocation, color, undefined, source.MemberNumber, craft, false);

--- a/src/club_existing/declarations.d.ts
+++ b/src/club_existing/declarations.d.ts
@@ -4,3 +4,9 @@ interface Window {
 	LSCG_Loaded?: boolean;
 	LSCG_Version?: string;
 }
+
+// TODO: Remove once >= R125 types are installed
+interface CraftingItem {
+	/** The crafted item effects mapped to their effect strength. */
+	Effects: Partial<Record<CraftingPropertyType, number>>;
+}


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5900](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5900)

BC R125 adds the ability to attach multiple crafted item properties (now renamed to "effects") to a single crafted item, superseding `CraftingItem.Property` with `CraftingItem.Effects` (while the old property will somewhat stick around for a while, it will soonly become inert). This PR adapts the LSCG "take gag" code to aforementioned change.