### PR TITLE
MAINT: Adapt to the R127 crafting `Slot` screen changes

### DIFF
--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -6,6 +6,7 @@ import { ActivityBundle, ActivityModule, ActivityTarget } from "./activities";
 import { CollarModule } from "./collar";
 import { InjectorModule } from "./injector";
 import { CommandListener } from "./core";
+import { ICONS } from "../utils";
 
 export const ScreenItems: string[] = [
 	"Phone1",
@@ -157,6 +158,11 @@ export interface GagTarget {
 	CraftedKeys?: string[];
 	PreferredTypes?: {Location: string, Type: number}[];
 	UsedAssetOverride?: string;
+}
+
+interface CraftingSlotModeData {
+	// @ts-expect-error: Requires R127 types
+	LSCGShare: CraftingSlotsMode.Data;
 }
 
 // Remote UI Module to handle configuration on other characters
@@ -500,40 +506,66 @@ export class ItemUseModule extends BaseModule {
 			next(args);
 		}, ModuleCategory.ItemUse);
 
-		hookFunction("CraftingRun", 1, (args, next) => {
-			next(args);
-			if (!Player || !Player.Crafting || CraftingReorderMode != "None" || CraftingMode != "Slot")
-				return;
+		if (GameVersion === "R126") {
+			hookFunction("CraftingRun", 1, (args, next) => {
+				next(args);
+				if (!Player || !Player.Crafting || CraftingReorderMode != "None" || CraftingMode != "Slot")
+					return;
 
-			for (let S = CraftingOffset; S < CraftingOffset + 20; S++) {
-				let X = ((S - CraftingOffset) % 4) * 500 + 15;
-				let Y = Math.floor((S - CraftingOffset) / 4) * 180 + 130;
-				let Craft = Player.Crafting[S];
-				if (!!Craft) {
-					DrawButton(X + 420, Y + 90, 40, 40, "", "White");
-					DrawImageResize("Icons/Chat.png", X + 420 + 2, Y + 90 + 2, 36, 36);
-					if (MouseIn(X + 420, Y + 90, 40, 40)) {
-						mouseTooltip("Share in chat", MouseX, MouseY, 2000);
-					}
-				}
-			}
-		}, ModuleCategory.ItemUse);
-
-		hookFunction("CraftingClick", 1, (args, next) => {
-			if (!!Player && !!Player.Crafting && CraftingReorderMode == "None" && CraftingMode == "Slot") {
 				for (let S = CraftingOffset; S < CraftingOffset + 20; S++) {
 					let X = ((S - CraftingOffset) % 4) * 500 + 15;
 					let Y = Math.floor((S - CraftingOffset) / 4) * 180 + 130;
 					let Craft = Player.Crafting[S];
-					if (!!Craft && MouseIn(X + 420, Y + 90, 40, 40)) {
-						this.DisplayCraft(Craft);
-						CraftingExit();
-						return;
+					if (!!Craft) {
+						DrawButton(X + 420, Y + 90, 40, 40, "", "White");
+						DrawImageResize("Icons/Chat.png", X + 420 + 2, Y + 90 + 2, 36, 36);
+						if (MouseIn(X + 420, Y + 90, 40, 40)) {
+							mouseTooltip("Share in chat", MouseX, MouseY, 2000);
+						}
 					}
 				}
-			}
-			return next(args);
-		}, ModuleCategory.ItemUse);
+			}, ModuleCategory.ItemUse);
+
+			hookFunction("CraftingClick", 1, (args, next) => {
+				if (!!Player && !!Player.Crafting && CraftingReorderMode == "None" && CraftingMode == "Slot") {
+					for (let S = CraftingOffset; S < CraftingOffset + 20; S++) {
+						let X = ((S - CraftingOffset) % 4) * 500 + 15;
+						let Y = Math.floor((S - CraftingOffset) / 4) * 180 + 130;
+						let Craft = Player.Crafting[S];
+						if (!!Craft && MouseIn(X + 420, Y + 90, 40, 40)) {
+							this.DisplayCraft(Craft);
+							CraftingExit();
+							return;
+						}
+					}
+				}
+				return next(args);
+			}, ModuleCategory.ItemUse);
+		} else {
+			// @ts-expect-error: Requires R127 types
+			CraftingSlots.modeData.LSCGShare = {
+				selectLabel: "Share",
+				/** @type {CraftingSlotsMode.Callback} */
+				callback: (crafts: readonly { craft: null | CraftingItem, button: HTMLButtonElement }[]) => {
+					crafts.forEach(({ craft, button }) => {
+						if (craft) {
+							button.addEventListener("click", () => {
+								this.DisplayCraft(craft);
+								CraftingExit(false);
+							});
+						} else {
+							button.disabled = true;
+						}
+					});
+					return {
+						heading: "LSCG: Share craft in chat",
+						modeAcceptTooltip: "Click on a craft to share it in the chat",
+						modeAcceptImgSrc: ICONS.BOUND_GIRL,
+						modeAcceptQuestionColor: "cyan",
+					};
+				},
+			};
+		}
 
 		Core().RegisterCommandListener(<CommandListener>{
             id: "craft_share_display",

--- a/src/main.scss
+++ b/src/main.scss
@@ -251,3 +251,8 @@
 		border-width: min(0.3dvh, 0.15dvw);
 	}
 }
+
+/* Add a minor background discoloration in order to subtely increase the contrast w.r.t. the other crafting modes */
+#crafting-slot-screen[data-mode="LSCGShare"] {
+	background-color: rgba(0, 255, 255, 0.06);
+}


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#6209](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6209)

Adapts LSCG to the planned R127 crafting `Slot` screen overhaul, converting it from canvas to DOM and overhaul just making the whole thing fancier. This PR introduces compatibility changes for LSCG's "share craft in chat" feature, utilizing the new crafting mode selection dropdown in order to switch the (default) button behavior to "share craft in chat".

~~Marking as draft until the upstream PR has been merged.~~

Examples
----------
Minor note: there is an actual dropdown right there at the start (from which `Share` was selected), but OBS has some issues actually capturing those.

https://github.com/user-attachments/assets/2112b545-8357-45a9-ab32-0aa30c3f75fd

