### PR TITLE
MAINT: Adjust to the R127 removal of `isTouchEvent` and fix an issue wherein canvas-attached event listeners weren't removed

### DIFF
--- a/src/Modules/opacity.scss
+++ b/src/Modules/opacity.scss
@@ -20,6 +20,7 @@
     display: flex;
     flex-direction: column;
 	padding-top: 1rem;
+	user-select: none;
 
 	.lscg-layers-body {
 		display: flex;
@@ -80,6 +81,7 @@
 	flex: 1 0 auto;
 	display: flex;
 	justify-content: space-between;
+	user-select: none;
 }
 
 #lscg-layers-translate-toolbar {

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -605,27 +605,21 @@ export class OpacityModule extends BaseModule {
 
     isDragging: boolean = false;
 
-    TranslateStart(evt: TouchEvent | MouseEvent) {
-        if (isTouchEvent(evt) && evt.changedTouches) {
-            if (evt.changedTouches.length > 1) return;
-        }
-
+    TranslateStart(elem: HTMLElement, evt: PointerEvent) {
         if (this.TranslationMode && MouseIn(700, 0, 500, 1000)) {
             this.isDragging = true;
             this.lastX = MouseX;
             this.lastY = MouseY;
         }
+        elem.setPointerCapture(evt.pointerId);
         let ui = document.getElementById(ID.root);
         if (!!ui) {
             ui.classList.add("lscg-translate-dragging");
         }
     }
 
-    TranslateMove(evt: TouchEvent | MouseEvent) {
+    TranslateMove(elem: HTMLElement, evt: PointerEvent) {
         if (!this.isDragging || !this.TranslationMode) return;
-        if (isTouchEvent(evt) && evt.changedTouches) {
-            if (evt.changedTouches.length > 1) return;
-        }
 
         let mX = Math.min(Math.max(MouseX, 700), 1200);
         let mY = Math.min(Math.max(MouseY, 0), 1000);
@@ -642,7 +636,8 @@ export class OpacityModule extends BaseModule {
         this.UpdatePreview();
     }
 
-    TranslateEnd(evt: TouchEvent | MouseEvent) {
+    TranslateEnd(elem: HTMLElement, evt: PointerEvent) {
+        elem.releasePointerCapture(evt.pointerId);
         this.isDragging = false;
         let ui = document.getElementById(ID.root);
         if (!!ui) {
@@ -757,14 +752,11 @@ export class OpacityModule extends BaseModule {
         let CanvasElement = document.getElementById("MainCanvas");
         if (!CanvasElement)
             return;
-        if (!CommonIsMobile) {
-            CanvasElement.addEventListener("mousedown", evt => this.TranslateStart(evt));
-            CanvasElement.addEventListener("mouseup", evt => this.TranslateEnd(evt));
-            CanvasElement.addEventListener("mousemove", evt => this.TranslateMove(evt));
-        }
-        CanvasElement.addEventListener("touchstart", evt => this.TranslateStart(evt));
-        CanvasElement.addEventListener("touchend", evt => this.TranslateEnd(evt));
-        CanvasElement.addEventListener("touchmove", evt => this.TranslateMove(evt));
+
+        CanvasElement.addEventListener("pointerdown", evt => this.TranslateStart(CanvasElement, evt));
+        CanvasElement.addEventListener("pointermove", evt => this.TranslateMove(CanvasElement, evt));
+        CanvasElement.addEventListener("pointerup", evt => this.TranslateEnd(CanvasElement, evt));
+        CanvasElement.addEventListener("pointercancel", evt => this.TranslateEnd(CanvasElement, evt));
 
         // Propagate the vanilla BC opacity slider changes to LSCG
         const rootID: string = ColorPicker.ids.root;
@@ -798,12 +790,10 @@ export class OpacityModule extends BaseModule {
         let CanvasElement = document.getElementById("MainCanvas");
         if (!CanvasElement)
             return;
-        CanvasElement.removeEventListener("mousedown", evt => this.TranslateStart(evt));
-        CanvasElement.removeEventListener("touchstart", evt => this.TranslateStart(evt));
-        CanvasElement.removeEventListener("mousemove", evt => this.TranslateMove(evt));
-        CanvasElement.removeEventListener("touchmove", evt => this.TranslateMove(evt));
-        CanvasElement.removeEventListener("mouseup", evt => this.TranslateEnd(evt));
-        CanvasElement.removeEventListener("touchend", evt => this.TranslateEnd(evt));
+        CanvasElement.removeEventListener("pointerdown", evt => this.TranslateStart(CanvasElement, evt));
+        CanvasElement.removeEventListener("pointermove", evt => this.TranslateMove(CanvasElement, evt));
+        CanvasElement.removeEventListener("pointerup", evt => this.TranslateEnd(CanvasElement, evt));
+        CanvasElement.removeEventListener("pointercancel", evt => this.TranslateEnd(CanvasElement, evt));
     }
 
     ResetTranslation() {

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -333,7 +333,6 @@ export class OpacityModule extends BaseModule {
     }
 
     onToggleTranslate(evt?: Event) {
-        console.info(evt);
         let opacity = document.getElementById(ID.opacity);
         let translate = document.getElementById(ID.translate);
         let allLayerCheck = document.getElementById(ID.allLayersCheck) as HTMLInputElement;

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -70,6 +70,8 @@ export class OpacityModule extends BaseModule {
     TranslateYElement: HTMLInputElement | undefined;
     lastX: number = 0;
     lastY: number = 0;
+    /** An abort controller for removing the canvas-attached translation listeners */
+    listenerRemover: null | AbortController = null;
 
     domUI = Object.freeze({
         shape: [40, 80, 650, 740] as RectTuple,
@@ -753,10 +755,11 @@ export class OpacityModule extends BaseModule {
         if (!CanvasElement)
             return;
 
-        CanvasElement.addEventListener("pointerdown", evt => this.TranslateStart(CanvasElement, evt));
-        CanvasElement.addEventListener("pointermove", evt => this.TranslateMove(CanvasElement, evt));
-        CanvasElement.addEventListener("pointerup", evt => this.TranslateEnd(CanvasElement, evt));
-        CanvasElement.addEventListener("pointercancel", evt => this.TranslateEnd(CanvasElement, evt));
+        const controller = this.listenerRemover = new AbortController();
+        CanvasElement.addEventListener("pointerdown", evt => this.TranslateStart(CanvasElement, evt), { signal: controller.signal });
+        CanvasElement.addEventListener("pointermove", evt => this.TranslateMove(CanvasElement, evt), { signal: controller.signal });
+        CanvasElement.addEventListener("pointerup", evt => this.TranslateEnd(CanvasElement, evt), { signal: controller.signal });
+        CanvasElement.addEventListener("pointercancel", evt => this.TranslateEnd(CanvasElement, evt), { signal: controller.signal });
 
         // Propagate the vanilla BC opacity slider changes to LSCG
         const rootID: string = ColorPicker.ids.root;
@@ -790,10 +793,10 @@ export class OpacityModule extends BaseModule {
         let CanvasElement = document.getElementById("MainCanvas");
         if (!CanvasElement)
             return;
-        CanvasElement.removeEventListener("pointerdown", evt => this.TranslateStart(CanvasElement, evt));
-        CanvasElement.removeEventListener("pointermove", evt => this.TranslateMove(CanvasElement, evt));
-        CanvasElement.removeEventListener("pointerup", evt => this.TranslateEnd(CanvasElement, evt));
-        CanvasElement.removeEventListener("pointercancel", evt => this.TranslateEnd(CanvasElement, evt));
+
+        // Remove the translation listeners
+        this.listenerRemover?.abort();
+        this.listenerRemover = null;
     }
 
     ResetTranslation() {


### PR DESCRIPTION
Follow up on https://github.com/littlesera/LSCG/pull/799

I had forgotten that the `isTouchEvent` got removed in the R127 beta (it's been unused in BC for some time), so this PR introduces some adjustments to that upstream change. This accompanied by just getting rid of the [`touch<x>`](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events) events (and [`mouse<x>`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent)), replacing them with their [`pointer<x>`](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) equivalent. The advantage of `pointer<x>` events is that they work for both mouse and touchpad, so there's no need for separate code paths anymore.

Secondly, this PR fixes an bug I stumbled upon during the R127 compatibility fix: LSCG would previously fail to remove the translation-related `touch<x>`/`mouse<x>` from the canvas upon exiting the screen, which, among others, would cause multiple of them to pile up again and again and again upon re-entering the coloring screen. This has now been fixed via setting a [`signal`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal) that can be used for removing the listeners.