### PR TITLE
fix(text): rectify possessive and intensive template use

### DIFF
--- a/src/Modules/hypno.ts
+++ b/src/Modules/hypno.ts
@@ -551,7 +551,7 @@ export class HypnoModule extends BaseModule {
         "%NAME%'s eyes flutter as %PRONOUN% fights to keep them open...",
         "%NAME% yawns and struggles to stay awake...",
         "%NAME% can feel %POSSESSIVE% eyelids grow heavy as %PRONOUN% drifts on the edge of sleep...",
-        "%NAME% takes a deep, relaxing breath as %POSSESSIVE% muscles relax and %PRONOUN% eyes start to droop..."
+        "%NAME% takes a deep, relaxing breath as %POSSESSIVE% muscles relax and %POSSESSIVE% eyes start to droop..."
     ]
 
     delayedActivations: Map<string, number> = new Map<string,number>();

--- a/src/Modules/injector.ts
+++ b/src/Modules/injector.ts
@@ -1224,7 +1224,7 @@ export class InjectorModule extends BaseModule {
     }
 
     breathSedativeEventStr: string[] = [
-        "%NAME%'s muscles relax limply as %PRONOUN% takes a deep breath of.",
+        "%NAME%'s muscles relax limply as %PRONOUN% takes a deep breath.",
         "%NAME%'s eyes flutter weakly as %PRONOUN% inhales.",
         "%NAME% struggles to keep %POSSESSIVE% drooping eyes open as %POSSESSIVE% device continues to emit its sedative gas."
     ];
@@ -1244,7 +1244,7 @@ export class InjectorModule extends BaseModule {
     breathAntidoteEventStr: string[] = [
         "%NAME% sighs with relief as %PRONOUN% takes a deep gulp of healing mist.",
         "%NAME% feels a tingle across %POSSESSIVE% skin as %POSSESSIVE% device heals %INTENSIVE%.",
-        "%NAME% lets out a quiet moan as %POSSESSIVE% device releases a healing mist into %INTENSIVE% lungs."
+        "%NAME% lets out a quiet moan as %POSSESSIVE% device releases a healing mist into %POSSESSIVE% lungs."
     ];
 
     BreathInDrugEvent() {


### PR DESCRIPTION
fixes minor incorrect use of `%PRONOUN%` and `%INTENSIVE%` in place of `%POSSESSIVE%`