### PR TITLE
BUG: FIx an issue with the opacity resize and the animation persisten storage data structure

### DIFF
--- a/src/Modules/States/AstralProjectionState.ts
+++ b/src/Modules/States/AstralProjectionState.ts
@@ -145,7 +145,7 @@ export class AstralProjectionState extends BaseState {
 
     RequestAnim() {
         for (let char of this.CharactersToRequestAnim) {
-            AnimationPersistentStorage[AnimationGetDynamicDataName(char, AnimationDataTypes.Rebuild)] = true;
+            AnimationRequestDraw(char);
         }
         this.CharactersToRequestAnim = [];
     }

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -374,7 +374,9 @@ export class OpacityModule extends BaseModule {
         this.SetTranslationElementValues();
     }
 
-    _prevResize: any;
+    /** Function for removing destroying the {@link CurrentScreenFunctions.Resize} coloring hook */
+    _unhookResize: null | (() => void) = null;
+
     load(): void {
         hookFunction("ItemColorLoad", 1, async (args, next) => {
             const ret = next(args);
@@ -390,8 +392,10 @@ export class OpacityModule extends BaseModule {
                     CurrentScreenFunctions = {} as ScreenFunctions;
                 }
 
-                this._prevResize = CurrentScreenFunctions.Resize;
-                CurrentScreenFunctions.Resize = (load) => this.ResizeDomUI(load);
+                this._unhookResize = hookFunction("CurrentScreenFunctions.Resize", 0, (args2, next) => {
+                    this.ResizeDomUI(...args2);
+                    return next(args);
+                });
                 CurrentScreenFunctions.Resize(true);
 
                 this.TranslateRemoveEventListener();
@@ -430,7 +434,8 @@ export class OpacityModule extends BaseModule {
             this.HideDomUI();
 
             this.TranslateRemoveEventListener();
-            CurrentScreenFunctions.Resize = this._prevResize;
+            this._unhookResize?.();
+            this._unhookResize = null;
         }, ModuleCategory.Opacity);
 
         // *** Hack in actual updating of the translation overrides ***


### PR DESCRIPTION
Fixes two issues:
* Ensure that `AnimationPersistentStorage` entries are assigned via the canonical `AnimationRequestDraw()` function (especially since the internal `AnimationPersistentStorage` was changed)
* Fixes an issue wherein the opacity module could assign an undefined to the chat room resize listener upon exiting, causing an exception down the line (see below for reproduction steps)

Reproduction steps:
-------------------------
<img width="647" height="221" alt="image" src="https://github.com/user-attachments/assets/f1fdac04-9524-42a4-ad9a-43ea0e8fb279" />

* go in a chat room
* open expression menu, pick emote, pick color, close color picker (cancel or save, makes no difference)
* by the time you're back on the player dialog, CurrentScreenFunctions.Resize is undefined