### PR TITLE
R127 fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ls-club-games",
-  "version": "0.8.7",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ls-club-games",
-      "version": "0.8.7",
+      "version": "0.8.9",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@types/lodash-es": "^4.17.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/node": "^25.3.0",
         "@types/semver": "^7.7.1",
-        "bc-stubs": "^126.0.0",
+        "bc-stubs": "^127.0.0",
         "concurrently": "^9.2.1",
         "eslint": "^10.0.1",
         "lodash-es": "^4.17.23",
@@ -1605,6 +1605,13 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@total-typescript/ts-reset": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz",
+      "integrity": "sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1795,12 +1802,13 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bc-stubs": {
-      "version": "126.0.0",
-      "resolved": "https://registry.npmjs.org/bc-stubs/-/bc-stubs-126.0.0.tgz",
-      "integrity": "sha512-391/Y2F/b5Fwh02QCu+M4pcuwtXbhWypO/VaNp7ItKucj5C9paWX9NA4mTQ3oBI5a6DGrXkv8Xer5tF4EfVxbA==",
+      "version": "127.0.0",
+      "resolved": "https://registry.npmjs.org/bc-stubs/-/bc-stubs-127.0.0.tgz",
+      "integrity": "sha512-GLAbaFdapOUPfv7wgI5Bo2ybsKMc0wn58i2c9qw0Ss6vh2tSZntuyHHSOg+Tq/h11wOjwfR1C/JLsAEwEICmZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@total-typescript/ts-reset": "^0.6.1",
         "socket.io-client": "4.6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^25.3.0",
     "@types/semver": "^7.7.1",
-    "bc-stubs": "^126.0.0",
+    "bc-stubs": "^127.0.0",
     "concurrently": "^9.2.1",
     "eslint": "^10.0.1",
     "lodash-es": "^4.17.23",

--- a/src/Modules/States/AstralProjectionState.ts
+++ b/src/Modules/States/AstralProjectionState.ts
@@ -145,7 +145,7 @@ export class AstralProjectionState extends BaseState {
 
     RequestAnim() {
         for (let char of this.CharactersToRequestAnim) {
-            AnimationPersistentStorage[AnimationGetDynamicDataName(char, AnimationDataTypes.Rebuild)] = true;
+            AnimationRequestDraw(char);
         }
         this.CharactersToRequestAnim = [];
     }

--- a/src/Modules/States/ResizedState.ts
+++ b/src/Modules/States/ResizedState.ts
@@ -85,7 +85,8 @@ export class ResizedState extends BaseState {
 
         hookFunction("CommonDrawAppearanceBuild", 1, (args, next) => {
             let C = args[0] as OtherCharacter;
-            C.HeightRatio = CharacterAppearanceGetCurrentValue(C, "Height", "Zoom");
+            const height = CharacterAppearanceGetCurrentValue(C, "Height", "Zoom");
+            if (height !== "None") C.HeightRatio = height;
             // Hack fix in case the body style was actually removed
             if (InventoryGet(C, "BodyStyle") == null) {
                 InventoryWear(C, "Original", "BodyStyle");
@@ -95,7 +96,8 @@ export class ResizedState extends BaseState {
 
         hookFunction("DrawCharacter", 1, (args, next) => {
             let C = args[0] as OtherCharacter;
-            C.HeightRatio = CharacterAppearanceGetCurrentValue(C, "Height", "Zoom");
+            const height = CharacterAppearanceGetCurrentValue(C, "Height", "Zoom");
+            if (height !== "None") C.HeightRatio = height
             return next(args);
         }, ModuleCategory.States);
     }

--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -160,9 +160,10 @@ export interface GagTarget {
 	UsedAssetOverride?: string;
 }
 
-interface CraftingSlotModeData {
-	// @ts-expect-error: Requires R127 types
-	LSCGShare: CraftingSlotsMode.Data;
+declare global {
+	interface CraftingSlotModeData {
+		LSCGShare: CraftingSlotsMode.Data;
+	}
 }
 
 interface QuickAccessButton {
@@ -726,66 +727,28 @@ export class ItemUseModule extends BaseModule {
 			next(args);
 		}, ModuleCategory.ItemUse);
 
-		if (GameVersion === "R126") {
-			hookFunction("CraftingRun", 1, (args, next) => {
-				next(args);
-				if (!Player || !Player.Crafting || CraftingReorderMode != "None" || CraftingMode != "Slot")
-					return;
-
-				for (let S = CraftingOffset; S < CraftingOffset + 20; S++) {
-					let X = ((S - CraftingOffset) % 4) * 500 + 15;
-					let Y = Math.floor((S - CraftingOffset) / 4) * 180 + 130;
-					let Craft = Player.Crafting[S];
-					if (!!Craft) {
-						DrawButton(X + 420, Y + 90, 40, 40, "", "White");
-						DrawImageResize("Icons/Chat.png", X + 420 + 2, Y + 90 + 2, 36, 36);
-						if (MouseIn(X + 420, Y + 90, 40, 40)) {
-							mouseTooltip("Share in chat", MouseX, MouseY, 2000);
-						}
+		CraftingSlots.modeData.LSCGShare = {
+			selectLabel: "Share",
+			/** @type {CraftingSlotsMode.Callback} */
+			callback: (crafts: readonly { craft: null | CraftingItem, button: HTMLButtonElement }[]) => {
+				crafts.forEach(({ craft, button }) => {
+					if (craft) {
+						button.addEventListener("click", () => {
+							this.DisplayCraft(craft);
+							CraftingExit(false);
+						});
+					} else {
+						button.disabled = true;
 					}
-				}
-			}, ModuleCategory.ItemUse);
-
-			hookFunction("CraftingClick", 1, (args, next) => {
-				if (!!Player && !!Player.Crafting && CraftingReorderMode == "None" && CraftingMode == "Slot") {
-					for (let S = CraftingOffset; S < CraftingOffset + 20; S++) {
-						let X = ((S - CraftingOffset) % 4) * 500 + 15;
-						let Y = Math.floor((S - CraftingOffset) / 4) * 180 + 130;
-						let Craft = Player.Crafting[S];
-						if (!!Craft && MouseIn(X + 420, Y + 90, 40, 40)) {
-							this.DisplayCraft(Craft);
-							CraftingExit();
-							return;
-						}
-					}
-				}
-				return next(args);
-			}, ModuleCategory.ItemUse);
-		} else {
-			// @ts-expect-error: Requires R127 types
-			CraftingSlots.modeData.LSCGShare = {
-				selectLabel: "Share",
-				/** @type {CraftingSlotsMode.Callback} */
-				callback: (crafts: readonly { craft: null | CraftingItem, button: HTMLButtonElement }[]) => {
-					crafts.forEach(({ craft, button }) => {
-						if (craft) {
-							button.addEventListener("click", () => {
-								this.DisplayCraft(craft);
-								CraftingExit(false);
-							});
-						} else {
-							button.disabled = true;
-						}
-					});
-					return {
-						heading: "LSCG: Share craft in chat",
-						modeAcceptTooltip: "Click on a craft to share it in the chat",
-						modeAcceptImgSrc: ICONS.BOUND_GIRL,
-						modeAcceptQuestionColor: "cyan",
-					};
-				},
-			};
-		}
+				});
+				return {
+					heading: "LSCG: Share craft in chat",
+					modeAcceptTooltip: "Click on a craft to share it in the chat",
+					modeAcceptImgSrc: ICONS.BOUND_GIRL,
+					modeAcceptQuestionColor: "cyan",
+				};
+			},
+		};
 
 		Core().RegisterCommandListener(<CommandListener>{
             id: "craft_share_display",

--- a/src/Modules/magic.ts
+++ b/src/Modules/magic.ts
@@ -434,7 +434,7 @@ export class MagicModule extends BaseModule {
                 // If this specific activity is clicked, we run it
                 if (!MouseIn(x, y, width, height)) return false;
                 let blocked = Array.isArray(blockedSpellTypes) && spell.Effects.some(effect => blockedSpellTypes.indexOf(effect) > -1);
-                spell = JSON.parse(JSON.stringify(spell));
+                spell = structuredClone(spell);
                 
                 if (!blocked) {
                     this.CastSpellInitial(spell, CurrentCharacter);
@@ -453,7 +453,7 @@ export class MagicModule extends BaseModule {
         if (!spell || this.settings.trueWildMagic)
             spell = this.RandomSpell
         let paired: Character | undefined = undefined;
-        spell = JSON.parse(JSON.stringify(spell));
+        spell = structuredClone(spell);
         if (this.SpellNeedsPair(spell))
             paired = this.PairedCharacterOptions(C)[getRandomInt(this.PairedCharacterOptions(C).length)];
         this.CastSpellActual(spell, C, false, paired);
@@ -1027,7 +1027,7 @@ export class MagicModule extends BaseModule {
         let spells = Player.LSCG.MagicModule.knownSpells.filter(s => s.AllowPotion && !s.Effects.some(e => pairedSpellEffects.indexOf(e) > -1));
         let spell = spells?.filter(x => !!x)?.find(x => !!x && !!x.Name && isPhraseInString(itemStr, x.Name));
         if (!!spell)
-            spell = JSON.parse(JSON.stringify(spell));
+            spell = structuredClone(spell);
             this.UnpackSpellCodes(spell);
             sendLSCGCommandBeep(senderNum, "get-spell-response", [{
                 name: "spell",

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -374,7 +374,9 @@ export class OpacityModule extends BaseModule {
         this.SetTranslationElementValues();
     }
 
-    _prevResize: any;
+    /** Function for removing destroying the {@link CurrentScreenFunctions.Resize} coloring hook */
+    _unhookResize: null | (() => void) = null;
+
     load(): void {
         hookFunction("ItemColorLoad", 1, async (args, next) => {
             const ret = next(args);
@@ -390,8 +392,10 @@ export class OpacityModule extends BaseModule {
                     CurrentScreenFunctions = {} as ScreenFunctions;
                 }
 
-                this._prevResize = CurrentScreenFunctions.Resize;
-                CurrentScreenFunctions.Resize = (load) => this.ResizeDomUI(load);
+                this._unhookResize = hookFunction("CurrentScreenFunctions.Resize", 0, (args2, next) => {
+                    this.ResizeDomUI(...args2);
+                    return next(args);
+                });
                 CurrentScreenFunctions.Resize(true);
 
                 this.TranslateRemoveEventListener();
@@ -430,7 +434,8 @@ export class OpacityModule extends BaseModule {
             this.HideDomUI();
 
             this.TranslateRemoveEventListener();
-            CurrentScreenFunctions.Resize = this._prevResize;
+            this._unhookResize?.();
+            this._unhookResize = null;
         }, ModuleCategory.Opacity);
 
         // *** Hack in actual updating of the translation overrides ***

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -388,12 +388,10 @@ export class OpacityModule extends BaseModule {
                 this.OpacityItem = Item;
 
                 this.ShowDomUI();
-                if (!CurrentScreenFunctions) {
-                    CurrentScreenFunctions = {} as ScreenFunctions;
-                }
 
                 this._unhookResize = hookFunction("CurrentScreenFunctions.Resize", 0, (args2, next) => {
-                    this.ResizeDomUI(...args2);
+                    const [load] = args2;
+                    this.ResizeDomUI(load);
                     return next(args);
                 });
                 CurrentScreenFunctions.Resize(true);

--- a/src/Settings/outfits.tsx
+++ b/src/Settings/outfits.tsx
@@ -362,7 +362,7 @@ export class GuiOutfits extends GuiSubscreen {
 
     charHook: (() => void) | undefined;
 
-    _prevResize: any;
+    _unhookResize: (() => void) | undefined;
     Load(): void {
         CommonPhotoMode = true;
         this.charHook = hookFunction("CharacterGetCurrent", 1, (args, next) => {
@@ -378,14 +378,13 @@ export class GuiOutfits extends GuiSubscreen {
         }
         
         this.#refreshListing();
-
-        if (!CurrentScreenFunctions) {
-            CurrentScreenFunctions = {} as ScreenFunctions;
-        }
         
         this.#updateElements();
-        this._prevResize = CurrentScreenFunctions.Resize;
-        CurrentScreenFunctions.Resize = (load) => this.Resize(load);
+        this._unhookResize = hookFunction("CurrentScreenFunctions.Resize", 0, (args, next) => {
+            const [load] = args;
+            this.Resize(load)
+            return next(args);
+        })
         CurrentScreenFunctions.Resize(true);
     }
 
@@ -428,7 +427,7 @@ export class GuiOutfits extends GuiSubscreen {
         DialogMenuMapping.items.Unload();
         if (!!this.charHook) this.charHook();
         CommonPhotoMode = false;
-        CurrentScreenFunctions.Resize = this._prevResize;
+        this._unhookResize?.();
         super.Exit();
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -364,7 +364,7 @@ export function parseFromBase64<T extends unknown>(data: string): T | undefined 
 	try {
 		const parsed = LZString.decompressFromBase64(data);
 		if (!parsed) return undefined;
-		return JSON.parse(parsed);
+		return JSON.parse(parsed) as T;
 	} catch (e) {
 		console.error(`failed to parse ${data}!`)
 		return undefined;
@@ -375,7 +375,7 @@ export function parseFromUTF16<T extends unknown>(data: string): T | undefined {
 	try {
 		const parsed = LZString.decompressFromUTF16(data);
 		if (!parsed) return undefined;
-		return JSON.parse(parsed);
+		return JSON.parse(parsed) as T;
 	} catch (e) {
 		console.error(`failed to parse ${data}!`)
 		return undefined;
@@ -422,7 +422,7 @@ export async function ImportSettings() {
 export function handleImportString(val: string): boolean {
 	if (!val) return false;
 	try {
-		let oldSettings = JSON.parse(JSON.stringify(Player.LSCG));
+		let oldSettings = structuredClone(Player.LSCG);
 		localStorage.setItem(`LSCG_${Player.MemberNumber}_Backup`, LZString.compressToBase64(JSON.stringify(oldSettings)));
 		let parsed = parseFromBase64<SettingsModel>(val);
 		if (!!parsed && !!parsed.GlobalModule) {
@@ -447,10 +447,10 @@ export function handleImportString(val: string): boolean {
 }
 
 export function CleanDefaultsFromSettings(settings: SettingsModel) : SettingsModel {
-	let newObj = JSON.parse(JSON.stringify(settings));
+	let newObj = structuredClone(settings);
 	Object.keys(newObj).forEach(key => {
 		let defaultModule = getModule(key);
-		let settingModule = (newObj as Record<string, unknown>)[key];
+		let settingModule = (newObj as unknown as Record<string, unknown>)[key];
 		if (!!defaultModule && !!defaultModule.defaultSettings) {
 			let defaults = defaultModule.defaultSettings as unknown as Record<string, unknown>;
 			_compareAndTrimObjects(defaults, settingModule);
@@ -1232,7 +1232,7 @@ export function CopyCharacter(C: Character, id: string, strip: boolean = true, r
 	let newCharacter = CharacterLoadSimple(`LSCG-${id || C.ID}`);
 	newCharacter.Name = C.Name;
 	newCharacter.Nickname = C.Nickname;
-	newCharacter.ArousalSettings = JSON.parse(JSON.stringify(C.ArousalSettings));
+	newCharacter.ArousalSettings = structuredClone(C.ArousalSettings);
 
 	newCharacter.Appearance = AppearanceItemParse(CharacterAppearanceStringify(C));
 	if (strip) StripCharacterNoRedraw(newCharacter);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,6 +172,8 @@ export function hookBCXVoice(listener: (v: {message: string, timer: number, send
 	return true;
 }
 
+// XXX: this is the proper function signature to get hook function type checking
+// export function hookFunction<FunctionName extends string>(target: FunctionName, priority: number, hook: PatchHook<GetDotedPathType<typeof globalThis, FunctionName>>, module: ModuleCategory | null = null): () => void {
 export function hookFunction(target: string, priority: number, hook: PatchHook, module: ModuleCategory | null = null): () => void {
 	const data = initPatchableFunction(target);
 


### PR DESCRIPTION
This goes on top of #803.

I had to fix up some more things because of ts-reset being enabled.

506a23e0ac794390c328887b613bad7853af6640 is the more relevant fix, since it's another case of a Resize temporary hook. The rest is mostly cleanup after the update to bc-stubs@^127, which I believe somehow cause ts-reset to be pulled, with another bunch of side-effects.