### PR TITLE
Update for BC R128

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ls-club-games",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ls-club-games",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@types/lodash-es": "^4.17.12",
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/node": "^25.3.0",
         "@types/semver": "^7.7.1",
-        "bc-stubs": "^127.0.0",
+        "bc-stubs": "^128.0.0",
         "concurrently": "^9.2.1",
         "eslint": "^10.0.1",
         "lodash-es": "^4.17.23",
@@ -1802,9 +1802,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bc-stubs": {
-      "version": "127.0.0",
-      "resolved": "https://registry.npmjs.org/bc-stubs/-/bc-stubs-127.0.0.tgz",
-      "integrity": "sha512-GLAbaFdapOUPfv7wgI5Bo2ybsKMc0wn58i2c9qw0Ss6vh2tSZntuyHHSOg+Tq/h11wOjwfR1C/JLsAEwEICmZg==",
+      "version": "128.0.0",
+      "resolved": "https://registry.npmjs.org/bc-stubs/-/bc-stubs-128.0.0.tgz",
+      "integrity": "sha512-12myItRFlzVnDB5xm2cVh0lmZJOE2xgKd4vXpxD3AEhUn3YmRYEanrYrzphc14R+Jha2OqxZlyfPAfR15kwE/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^25.3.0",
     "@types/semver": "^7.7.1",
-    "bc-stubs": "^127.0.0",
+    "bc-stubs": "^128.0.0",
     "concurrently": "^9.2.1",
     "eslint": "^10.0.1",
     "lodash-es": "^4.17.23",

--- a/src/Modules/States/AstralProjectionState.ts
+++ b/src/Modules/States/AstralProjectionState.ts
@@ -191,7 +191,7 @@ export class AstralProjectionState extends BaseState {
             if (IsSoulBind(CA) && opacityEnabled && C.CharacterID.indexOf("LSCGAstralProjectionCorporeal") > -1) {
                 let layerName = L?.trim() ?? "";
                 let layerIx = CA.Asset.Layer.findIndex(l => l.Name == layerName);
-                let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? CA.Asset.Opacity;
+                let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? 1;
                 let curOpacity = ret.Opacity ?? originalLayerOpacity ?? 1;
                 ret.Opacity = curOpacity * .4;
                 ret.AlphaMasks = [];

--- a/src/Modules/States/AstralProjectionState.ts
+++ b/src/Modules/States/AstralProjectionState.ts
@@ -3,6 +3,7 @@ import { BaseState } from "./BaseState";
 import { StateModule } from "Modules/states";
 import { ModuleCategory } from "Settings/setting_definitions";
 import { debounce } from 'lodash-es';
+import { GetDotedPathType, PatchHook } from "bondage-club-mod-sdk";
 
 // TODO:
 // - Allow 'soulbind' bindings to be added to ghost and carry over from corporeal form if applied there.
@@ -177,29 +178,25 @@ export class AstralProjectionState extends BaseState {
 
         hookFunction("CommonCallFunctionByName", 1, (args, next) => {
             if (!this.StateModule.Enabled) return next(args);
-            let funcName = args[0];
-            let params = args[1];
-            if (!params) {
+            const [funcName, funcArgs] = args;
+            if (!/Assets(.+)BeforeDraw/i.test(funcName) || !funcArgs) {
                 return next(args);
             }
 
-            let C = params['C'] as OtherCharacter;
-            let CA = params['CA'] as Item;
-            let regex = /Assets(.+)BeforeDraw/i;
-            if (regex.test(funcName)) {
-                let opacityEnabled = (Player.LSCG?.OpacityModule?.enabled ?? true);
-                let ret = next(args) ?? {};
-                if (IsSoulBind(CA) && opacityEnabled && C.CharacterID.indexOf("LSCGAstralProjectionCorporeal") > -1) {
-                    let layerName = (params['L'] as string ?? "")?.trim() ?? "";
-                    let layerIx = CA.Asset.Layer.findIndex(l => l.Name == layerName);
-                    let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? CA.Asset.Opacity;
-                    let curOpacity = ret.Opacity ?? originalLayerOpacity ?? 1;
-                    ret.Opacity = curOpacity * .4;
-                    ret.AlphaMasks = [];
-                }
-                return ret;
-            } else
-                return next(args);
+            const params = funcArgs as Parameters<PatchHook<GetDotedPathType<typeof globalThis, "AssetsItemArmsHempRopeBeforeDraw">>>[0][0]
+            const { C: origC, CA, L } = params;
+            const C = origC as OtherCharacter;
+            let opacityEnabled = (Player.LSCG?.OpacityModule?.enabled ?? true);
+            let ret = next(args) ?? {};
+            if (IsSoulBind(CA) && opacityEnabled && C.CharacterID.indexOf("LSCGAstralProjectionCorporeal") > -1) {
+                let layerName = L?.trim() ?? "";
+                let layerIx = CA.Asset.Layer.findIndex(l => l.Name == layerName);
+                let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? CA.Asset.Opacity;
+                let curOpacity = ret.Opacity ?? originalLayerOpacity ?? 1;
+                ret.Opacity = curOpacity * .4;
+                ret.AlphaMasks = [];
+            }
+            return ret;
         }, ModuleCategory.States)
 
         hookFunction("CharacterLoadCanvas", 1, (args, next) => {

--- a/src/Modules/States/XRayVisionState.ts
+++ b/src/Modules/States/XRayVisionState.ts
@@ -72,7 +72,7 @@ export class XRayVisionState extends BaseState {
             if (opacityEnabled && this.CanViewXRay(C) && !!CA && isCloth(CA) && !(params['Property']?.LSCGLeadLined ?? false)) {
                 let layerName = L?.trim() ?? "";
                 let layerIx = CA.Asset.Layer.findIndex(l => l.Name == layerName);
-                let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? CA.Asset.Opacity;
+                let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? 1;
                 let curOpacity = ret.Opacity ?? originalLayerOpacity ?? 1;
                 ret.Opacity = curOpacity * .5;
                 ret.AlphaMasks = [];

--- a/src/Modules/States/XRayVisionState.ts
+++ b/src/Modules/States/XRayVisionState.ts
@@ -3,6 +3,7 @@ import { BaseState } from "./BaseState";
 import { StateModule } from "Modules/states";
 import { ModuleCategory } from "Settings/setting_definitions";
 import { getModule } from "modules";
+import { GetDotedPathType, PatchHook } from "bondage-club-mod-sdk";
 
 export class XRayVisionState extends BaseState {
     XRayKeywords: string[] = [
@@ -57,28 +58,26 @@ export class XRayVisionState extends BaseState {
 
     Init(): void {
         hookFunction("CommonCallFunctionByName", 1, (args, next) => {
-            let funcName = args[0];
-            let params = args[1];
-            if (!params) {
+            const [funcName, funcArgs] = args;
+            if (!/Assets(.+)BeforeDraw/i.test(funcName) || !funcArgs || !this.Active) {
                 return next(args);
             }
-            let C = params['C'] as OtherCharacter;
-            let CA = params['CA'] as Item;
-            let regex = /Assets(.+)BeforeDraw/i;
-            if (regex.test(funcName) && this.Active) {
-                let opacityEnabled = Player.IsPlayer() && (Player.LSCG?.OpacityModule?.enabled ?? true);
-                let ret = next(args) ?? {};
-                if (opacityEnabled && this.CanViewXRay(C) && !!CA && isCloth(CA) && !(params['Property']?.LSCGLeadLined ?? false)) {
-                    let layerName = (params['L'] as string ?? "")?.trim() ?? "";
-                    let layerIx = CA.Asset.Layer.findIndex(l => l.Name == layerName);
-                    let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? CA.Asset.Opacity;
-                    let curOpacity = ret.Opacity ?? originalLayerOpacity ?? 1;
-                    ret.Opacity = curOpacity * .5;
-                    ret.AlphaMasks = [];
-                }
-                return ret;
-            } else
-                return next(args);
+
+            const params = funcArgs as Parameters<PatchHook<GetDotedPathType<typeof globalThis, "AssetsItemArmsHempRopeBeforeDraw">>>[0][0]
+            const { C: origC, CA, L } = params;
+            const C = origC as OtherCharacter;
+
+            let opacityEnabled = Player.IsPlayer() && (Player.LSCG?.OpacityModule?.enabled ?? true);
+            let ret = next(args) ?? {};
+            if (opacityEnabled && this.CanViewXRay(C) && !!CA && isCloth(CA) && !(params['Property']?.LSCGLeadLined ?? false)) {
+                let layerName = L?.trim() ?? "";
+                let layerIx = CA.Asset.Layer.findIndex(l => l.Name == layerName);
+                let originalLayerOpacity = (Array.isArray(CA?.Property?.Opacity) ? CA?.Property?.Opacity[layerIx] : CA.Property?.Opacity) ?? CA.Asset.Opacity;
+                let curOpacity = ret.Opacity ?? originalLayerOpacity ?? 1;
+                ret.Opacity = curOpacity * .5;
+                ret.AlphaMasks = [];
+            }
+            return ret;
         }, ModuleCategory.States);
     }
 

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -511,24 +511,23 @@ export class OpacityModule extends BaseModule {
                 if (opacity == null) {
                     hasOpacitySettings = false;
                 } else if (typeof opacity === "number") {
-                    hasOpacitySettings = item.Asset.Opacity !== opacity;
+                    hasOpacitySettings = item.Asset.Layer.some(l => l.Opacity !== opacity);
                 } else if (Array.isArray(opacity)) {
                     hasOpacitySettings = !opacity.every((opac, i) => opac === item.Asset.Layer[i]?.Opacity);
                 }
                 if ((hasOpacitySettings || xrayActive || IsSoulBind(item)) && !item.Property?.LSCGLeadLined) {
-                    item.Asset = Object.assign({}, item.Asset);
-                    (item.Asset as any).Layer = item.Asset.Layer.map(l => Object.assign({}, l));
-                    item?.Asset?.Layer?.forEach(layer => {
-                        (layer as any).Alpha = [];
-                    });
-                    (item.Asset as any).Hide = [];
-                    (item.Asset as any).HideItem = [];
-                    (item.Asset as any).HideItemAttribute = [];
+                    const asset: Mutable<Asset> = Object.assign({}, item.Asset);
+                    item.Asset = asset;
+                    asset.Layer = asset.Layer.map(l => Object.assign({}, l, { Alpha: [], }));
+                    asset.Hide = [];
+                    asset.HideItem = [];
+                    asset.HideItemAttribute = [];
                 } else {
                     let defaultAsset = AssetMap.get(`${item?.Asset?.Group?.Name}/${item.Asset.Name}`);
                     if (!!defaultAsset) {
-                        item.Asset = Object.assign({}, defaultAsset);
-                        (item.Asset as any).Layer = defaultAsset.Layer.map(l => Object.assign({}, l));
+                        const asset : Mutable<Asset> = Object.assign({}, defaultAsset);
+                        item.Asset = asset;
+                        asset.Layer = defaultAsset.Layer.map(l => Object.assign({}, l));
                     }
                 }
 
@@ -799,11 +798,12 @@ export class OpacityModule extends BaseModule {
     }
 
     ResetTranslation() {
-        if (!this.OpacityItem || !this.OpacityItem.Property || !(this.OpacityItem.Property as PropertiesWithLayerOverrides).LayerOverrides)
+        const properties = this.OpacityItem?.Property as PropertiesWithLayerOverrides;
+        if (!this.OpacityItem || !this.OpacityItem.Property || !properties.LayerOverrides)
             return;
-        (this.OpacityItem.Property as PropertiesWithLayerOverrides).LayerOverrides?.forEach(layer => {
-            layer.DrawingLeft = this.OpacityItem?.Asset.DrawingLeft;
-            layer.DrawingTop = this.OpacityItem?.Asset.DrawingTop;
+        properties.LayerOverrides.forEach((layer, i) => {
+            layer.DrawingLeft = this.OpacityItem?.Asset.Layer[i]?.DrawingLeft ?? { [PoseType.DEFAULT]: 1, };
+            layer.DrawingTop = this.OpacityItem?.Asset.Layer[i]?.DrawingTop ?? { [PoseType.DEFAULT]: 1, };
             this.SelectedTranslationLayer = -1;
         });
         this.SetTranslationElementValues();

--- a/src/Modules/opacity.tsx
+++ b/src/Modules/opacity.tsx
@@ -8,6 +8,7 @@ import { StateModule } from "./states";
 import { endsWith, kebabCase, replace } from "lodash-es";
 import styles from "./opacity.scss?inline";
 import { IsSoulBind } from "./States/AstralProjectionState";
+import { GetDotedPathType, PatchHook } from "bondage-club-mod-sdk";
 
 interface OpacitySlider {
     ElementId: string;
@@ -21,7 +22,7 @@ interface TranslationValue {
 }
 
 interface PropertiesWithLayerOverrides extends ItemProperties {
-    LayerOverrides: any[];
+    LayerOverrides: { DrawingLeft: TopLeft.Data; DrawingTop: TopLeft.Data; }[];
 }
 
 const root = "lscg-layers";
@@ -438,47 +439,43 @@ export class OpacityModule extends BaseModule {
 
         // *** Hack in actual updating of the translation overrides ***
         hookFunction("CommonCallFunctionByNameWarn", 2, (args, next) => {
-            let funcName = args[0];
-            let params = args[1];
-            if (!params) {
+            const [funcName, funcArgs] = args;
+            if (!/Assets(.+)BeforeDraw/i.test(funcName) || !funcArgs) {
                 return next(args);
             }
-            let C = params['C'] as OtherCharacter;
-            let CA = params['CA'] as Item;
-            let groupName = params['GroupName'];
-            let Property = params['Property'];
-            let regex = /Assets(.+)BeforeDraw/i;
-            if (regex.test(funcName)) {
-                let ret = CommonCallFunctionByName(args[0], args[1]) ?? {};
-                if (this.Enabled && !!CA && isDrawingOverridable(CA) && !!Property) {
-                    let layerName = (params['L'] as string ?? "").trim();
-                    if (layerName[0] == '_')
-                        layerName = layerName.slice(1);
-                    let layerIx = CA.Asset.Layer.findIndex(l => (l.Name ?? "") == layerName);
 
-                    let xOverride = Property?.LayerOverrides?.[layerIx]?.DrawingLeft?.[PoseType.DEFAULT] ?? undefined;
-                    let yOverride = Property?.LayerOverrides?.[layerIx]?.DrawingTop?.[PoseType.DEFAULT] ?? undefined;
+            const params = funcArgs as Parameters<PatchHook<GetDotedPathType<typeof globalThis, "AssetsItemArmsHempRopeBeforeDraw">>>[0][0]
+            const { C: origC, CA, GroupName: groupName, Property: origProp, L } = params;
+            const C = origC as OtherCharacter;
+            const Property = origProp as PropertiesWithLayerOverrides;
+            const ret = CommonCallFunctionByName(...args) ?? {};
+            if (this.Enabled && !!CA && isDrawingOverridable(CA) && !!Property) {
+                let layerName = L.trim();
+                if (layerName[0] == '_')
+                    layerName = layerName.slice(1);
+                let layerIx = CA.Asset.Layer.findIndex(l => (l.Name ?? "") == layerName);
 
-                    // Adjust for pose. BIGGER change would be to actually save the lscg translate as offsets instead of overrides... which... should be done but will suck >.<
-                    if (!!xOverride || !!yOverride) {
-                        for (const drawPose of C.DrawPose) {
-                            const PoseDef = PoseRecord[drawPose];
-                            if (PoseDef && PoseDef.MovePosition) {
-                                const MovePosition = PoseDef.MovePosition.find(MP => MP.Group === groupName);
-                                if (MovePosition) {
-                                    if (!!xOverride) xOverride += MovePosition.X;
-                                    if (!!yOverride) yOverride += MovePosition.Y;
-                                }
+                let xOverride = Property?.LayerOverrides?.[layerIx]?.DrawingLeft?.[PoseType.DEFAULT] ?? undefined;
+                let yOverride = Property?.LayerOverrides?.[layerIx]?.DrawingTop?.[PoseType.DEFAULT] ?? undefined;
+
+                // Adjust for pose. BIGGER change would be to actually save the lscg translate as offsets instead of overrides... which... should be done but will suck >.<
+                if (!!xOverride || !!yOverride) {
+                    for (const drawPose of C.DrawPose) {
+                        const PoseDef = PoseRecord[drawPose];
+                        if (PoseDef && PoseDef.MovePosition) {
+                            const MovePosition = PoseDef.MovePosition.find(MP => MP.Group === groupName);
+                            if (MovePosition) {
+                                if (!!xOverride) xOverride += MovePosition.X;
+                                if (!!yOverride) yOverride += MovePosition.Y;
                             }
                         }
                     }
-
-                    if (!!xOverride) ret.X = xOverride;
-                    if (!!yOverride) ret.Y = yOverride + CanvasUpperOverflow;
                 }
-                return ret
-            } else
-                return next(args);
+
+                if (!!xOverride) ret.X = xOverride;
+                if (!!yOverride) ret.Y = yOverride + CanvasUpperOverflow;
+            }
+            return ret
         }, ModuleCategory.Opacity);
     }
 

--- a/src/Settings/outfits.tsx
+++ b/src/Settings/outfits.tsx
@@ -929,7 +929,7 @@ export class GuiOutfits extends GuiSubscreen {
         });
     }
 
-    ClickInventoryMenu(button: DialogMenuButton) {
+    ClickInventoryMenu(button: DialogMenuButtonType) {
         console.info(`Button press: ${button}`);
     }
 


### PR DESCRIPTION
Not properly tested; as usual, bumped bc-stubs, then whacked everything back into shape so TS stayed down.

The first 3 commits are just that. The last commit (if I didn't mess up) is where stuff gets a bit shoddy, since I lack the knowledge about the inner workings of LSCG; but it's the one point where I adapt the code to the removal of all of the transient properties (the ones that were only there so the `AssetAdd` process could inherit values around), like `Opacity` and `DrawingTop/Left`.

It does mean that, if what I (shoddily) implemented isn't enough, you'll have to go look back at the raw definitions in `AssetFemale3DCG` to grab the values out of there (I'm looking at that drawing coordinate reset, for example).

The other issue is that, while <https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6337> is not merged, there's not much you can do here, since I papered over your papering over by putting back all of the real assets in. Sorry about that, I should have checked what you were up to before doing a hotfix for that 😬.

Anyway, looking at what you're doing in there, and given that whole "shadow assets" doesn't quite vibe with me, I have a hunch it might be possible to get the same results by patching into `CharacterAppearanceVisible`? WCE already does that for its own hide overriding, so you wouldn't be alone 😅.