### PR TITLE
fix(item-use): disable buggy tamperproofing against third-party assist

### DIFF
--- a/src/Modules/item-use.ts
+++ b/src/Modules/item-use.ts
@@ -713,7 +713,7 @@ export class ItemUseModule extends BaseModule {
 		}, ModuleCategory.ItemUse);
 
 		hookFunction("StruggleMinigameStart", 1, (args, next) => {
-			this.Struggling = true;
+			if (args[0].IsPlayer()) this.Struggling = true;
 			next(args);
 		})
 


### PR DESCRIPTION
> the changes and rationale of this PR has been explained in the commit description which has been cloned here.

This commit stops a `StruggleMinigameStart` that isn't on the player themselves from triggering tamperproof behaviors.
It is done by introducing a `C.IsPlayer()` check before setting `this.Struggling` to `true` on the `StruggleMinigameStart` hook.

There is a case where a struggle minigame is started on another character instead of the player which can result in a buggy message:
1. X has a self-tightening tamperproof binding with a lock...
2. Y tries to lockpick it but fails... and the following is sent...
3. "Y's <binding> tightens around them, countering their tampering."
instead of the following which makes more sense...
"X's <binding> tightens around them, countering Y's tampering."

The reason why I have opted to completely disable this code path is because it didn't seem like tamperproof was meant to work this way at all...
as in... struggles on a third-party doesn't seem supported in the first place, since even if we fixed the message appropriately...
the self-tightening counter effect doesn't actually apply at all, since it'd try to lookup the Player's own appearance...
and not the appearance of the one the player is assisting.
xref: https://github.com/littlesera/LSCG/blob/main/src/Modules/item-use.ts#L1881-L1884

As for the other effects, it's up for debate whether it makes sense for the character helping another struggle to be sedated or shocked...
I think this warrants a revisit to the logic for cases where someone is helping another struggle.
Henceforth, I believe it is better to disable this codepath for now.

The bug lies specifically when `StruggleMinigameStart` is called with a `C` argument that isn't the player themselves...
This has been found out to occur when a player tries to lockpick others... i.e. when `StruggleProgressCurrentMinigame` is `"LockPick"`...
xref: https://gitgud.io/BondageProjects/Bondage-College/-/blob/master/BondageClub/Scripts/Dialog.js?ref_type=heads#L1851

The character the struggling minigame is done on could also be not the player in other cases as well... which would lead to the bug too...
xref: https://gitgud.io/BondageProjects/Bondage-College/-/blob/master/BondageClub/Scripts/Dialog.js?ref_type=heads#L5749