### PR TITLE
MAINT: Adapt to the R130 activity text cache changes

### DIFF
--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -1909,6 +1909,13 @@ export class ActivityModule extends BaseModule {
     }
 
     AddTargetToActivity(activity: LSCGActivity, tgt: ActivityTarget) {
+        let textCachePush: (key: string, value: string) => void;
+        if (GameVersion === "R129") {
+            textCachePush = (key, value) => ActivityDictionary?.push([key, value]);
+        } else { // >= R130Beta1
+            const textCache = TextPrefetchFile(ScreenFileGetPath("ActivityDictionary.csv", "Character", "Preference"));
+            textCachePush = (key, value) => textCache.cache[key] = value;
+        }
         tgt.TargetLabel = tgt.TargetLabel ?? activity.Name.substring(5);
 
         if (tgt.SelfAllowed) {
@@ -1929,29 +1936,29 @@ export class ActivityModule extends BaseModule {
         }
 
         if (!!tgt.TargetLabel) {
-            ActivityDictionary?.push([
+            textCachePush(
                 "Label-ChatOther-" + tgt.Name + "-" + activity.Name,
                 tgt.TargetLabel
-            ]);
+            );
         }
 
         if (!!tgt.TargetAction) {
-            ActivityDictionary?.push([
+            textCachePush(
                 "ChatOther-" + tgt.Name + "-" + activity.Name,
-                tgt.TargetAction
-            ]);
+                tgt.TargetAction,
+            );
         }
 
         if (tgt.SelfAllowed) {
-            ActivityDictionary?.push([
+            textCachePush(
                 "Label-ChatSelf-" + tgt.Name + "-" + activity.Name,
-                tgt.TargetSelfLabel ?? tgt.TargetLabel
-            ]);
+                tgt.TargetSelfLabel ?? tgt.TargetLabel,
+            );
 
-            ActivityDictionary?.push([
+            textCachePush(
                 "ChatSelf-" + tgt.Name + "-" + activity.Name,
-                tgt.TargetSelfAction ?? tgt.TargetAction
-            ]);
+                tgt.TargetSelfAction ?? tgt.TargetAction,
+            );
         }
     }
 

--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -1913,7 +1913,7 @@ export class ActivityModule extends BaseModule {
         if (GameVersion === "R129") {
             textCachePush = (key, value) => ActivityDictionary?.push([key, value]);
         } else { // >= R130Beta1
-            const textCache = TextPrefetchFile(ScreenFileGetPath("ActivityDictionary.csv", "Character", "Preference"));
+            const textCache = ActivityDictionaryLoad();
             textCachePush = (key, value) => textCache.cache[key] = value;
         }
         tgt.TargetLabel = tgt.TargetLabel ?? activity.Name.substring(5);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1105,8 +1105,8 @@ export function activityHasDictionaryText(KeyWord: string) {
 			if (ActivityDictionary[D][0] == KeyWord)
 				return true;
 		return false;
-	} else { // >= R130Beta1
-		const textCache = TextPrefetchFile(ScreenFileGetPath("ActivityDictionary.csv", "Character", "Preference"));
+	} else { // >= R130Beta2
+		const textCache = ActivityDictionaryLoad();
 		if (!textCache.loaded) {
 			return;
 		} else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1095,15 +1095,24 @@ export function getActivityLabel(activity: Activity, group: AssetGroup) {
 }
 
 export function activityHasDictionaryText(KeyWord: string) {
-	if (!ActivityDictionary)
-		ActivityDictionaryLoad();
-	if (!ActivityDictionary)
-		return;
+	if (GameVersion === "R129") {
+		if (!ActivityDictionary)
+			ActivityDictionaryLoad();
+		if (!ActivityDictionary)
+			return;
 
-	for (let D = 0; D < ActivityDictionary.length; D++)
-		if (ActivityDictionary[D][0] == KeyWord)
-			return true;
-	return false;
+		for (let D = 0; D < ActivityDictionary.length; D++)
+			if (ActivityDictionary[D][0] == KeyWord)
+				return true;
+		return false;
+	} else { // >= R130Beta1
+		const textCache = TextPrefetchFile(ScreenFileGetPath("ActivityDictionary.csv", "Character", "Preference"));
+		if (!textCache.loaded) {
+			return;
+		} else {
+			return textCache.cache[KeyWord] !== undefined;
+		}
+	}
 }
 
 export function getZoneColor(groupName: string, hasConfiguration: boolean): string {


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#6397](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6397)

R130 gets rid the custom activity dictionary logic previously used, replacing it with a more standard `TextCache` object. This PR adds the required compatibility changes for LSCG's custom activities.