### PR TITLE
Fix activity text substitution

### DIFF
--- a/src/Modules/activities.ts
+++ b/src/Modules/activities.ts
@@ -119,7 +119,7 @@ export class ActivityModule extends BaseModule {
             let msg = ActivityDictionaryText(data.Content);
             msg = CommonStringSubstitute(msg, substitutions ?? [])
             data.Dictionary?.push({
-                Tag: "MISSING ACTIVITY DESCRIPTION FOR KEYWORD " + data.Content,
+                Tag: `${TEXT_NOT_FOUND_PREFIX} "ActivityDictionary.csv": ${data.Content}`,
                 Text: msg
             });
 

--- a/src/Modules/chaotic-item.ts
+++ b/src/Modules/chaotic-item.ts
@@ -220,7 +220,7 @@ class PropertyMutator {
             // Idk why but this AssetTextGet almost always fail to retrieve the correct text.
             // And because the string to retrieve the asset's text don't follow any logics, we probably cannot do better
             let propertyName = AssetTextGet(item.Asset.Name + selectedProperty) ?? selectedProperty;
-            if (propertyName.includes("MISSING")) {
+            if (propertyName.startsWith(TEXT_NOT_FOUND_PREFIX)) {
                 propertyName = customPropertyName ?? selectedProperty ?? "unknown property";
             }
             SendAction(`%NAME%'s ${itemName} changed the ${propertyName} settings by itself to ${propertyChangeResult?.newValueStr}`);


### PR DESCRIPTION
Fix the replacement tags being wrong, which makes the raw string show up on non-LSCG clients.

`(MISSING TEXT IN "ActivityDictionary.csv": ChatSelf-ItemMouth-LSCG_SwallowLoad)` instead of the old, specific ACTIVITY DESCRIPTION one, now that the text loading systems have been merged.